### PR TITLE
v1.1.0: Ritual deepening, versioning, and PR CI gates

### DIFF
--- a/.cursor/rules/penumbra.mdc
+++ b/.cursor/rules/penumbra.mdc
@@ -1,5 +1,5 @@
 ---
-description: Penumbra agent principles — privacy, Supabase, EAA, themes, GitHub Issues ritual
+description: Penumbra agent principles — privacy, Supabase, EAA, themes, GitHub Issues ritual, versioning
 alwaysApply: true
 ---
 
@@ -11,4 +11,5 @@ alwaysApply: true
 - EAA/EN 301 549 is the accessibility bar. Do not claim full conformance. High-contrast is true B/W.
 - Themes persist. Canvas ritual: Place, nearby echo, Index as conversation.
 - GitHub Issues + Project is the development Kanban: `status:in-progress` before coding, close + comment when landed. Use `gh`, not Atlassian.
+- Never commit on `main`. Branch `{major|minor|patch}/vX.Y.Z-{slug}`, bump `pubspec.yaml` to match, PR into `main`. See `docs/versioning.md`.
 - Honesty over badges. Making-of and ADRs stay true.

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
-LUMEN_CONTROLLER_NAME=Lumen controller (placeholder)
-LUMEN_CONTROLLER_EMAIL=privacy@example.invalid
-LUMEN_ORIGIN=http://localhost
+PENUMBRA_CONTROLLER_NAME=Penumbra controller (placeholder)
+PENUMBRA_CONTROLLER_EMAIL=privacy@example.invalid
+PENUMBRA_ORIGIN=http://localhost
+# Optional. Without it, echoes stay local.
+# GEMINI_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           name: sbom
           path: build/sbom.cdx.json
       - name: OSV scan
-        uses: google/osv-scanner-action@v2.5.1
+        uses: google/osv-scanner-action/osv-scanner-action@v2.5.1
         with:
           scan-args: |-
             --lockfile=pubspec.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           name: sbom
           path: build/sbom.cdx.json
       - name: OSV scan
-        uses: google/osv-scanner-action@v2
+        uses: google/osv-scanner-action@v2.5.1
         with:
           scan-args: |-
             --lockfile=pubspec.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   FLUTTER_VERSION: "3.44.1"
 
 jobs:
-  test:
+  analyze:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +24,47 @@ jobs:
           cache: true
       - run: flutter pub get
       - run: dart analyze --fatal-warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - run: flutter pub get
       - run: flutter test --coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info
+          if-no-files-found: ignore
+
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - run: flutter build web --release
+      - run: mkdir -p build/web/.well-known && cp web/.well-known/security.txt build/web/.well-known/security.txt && cp web/_headers build/web/_headers
+
+  supply-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - run: flutter pub get
       - run: dart run tool/generate_sbom.dart build/sbom.cdx.json
       - uses: actions/upload-artifact@v4
         with:
@@ -34,7 +78,7 @@ jobs:
         continue-on-error: false
 
   deploy:
-    needs: test
+    needs: [analyze, test, build-web, supply-chain]
     if: github.ref == 'refs/heads/main' && vars.CLOUDFLARE_PROJECT_NAME != ''
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -35,6 +35,15 @@ jobs:
             echo "PROJECTS_TOKEN is not set; skipping Projects v2 sync."
             exit 0
           fi
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            numbers=$(echo "${PR_BODY:-}" | grep -Eo '(Fixes|Closes|Resolves)[[:space:]]+#[0-9]+' | grep -Eo '[0-9]+' || true)
+            if [ -z "${numbers}" ]; then
+              echo "PR has no Fixes/Closes/Resolves keywords; skipping Projects sync."
+              exit 0
+            fi
+          fi
+
           export GH_TOKEN="${PROJECTS_TOKEN}"
 
           meta=$(gh api graphql -f query='
@@ -61,7 +70,10 @@ jobs:
                   }
                 }
               }
-            }' -F owner="$OWNER" -F number="$PROJECT_NUMBER")
+            }' -F owner="$OWNER" -F number="$PROJECT_NUMBER") || {
+            echo "GraphQL lookup failed; skipping Projects v2 sync."
+            exit 0
+          }
 
           project_id=$(echo "$meta" | jq -r '.data.user.projectV2.id // .data.organization.projectV2.id')
           field_id=$(echo "$meta" | jq -r '.data.user.projectV2.field.id // .data.organization.projectV2.field.id')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,22 @@ Read this first. Product is small; craft is the interview artifact.
 
 ## GitHub Issues + Project (development board)
 
-GitHub is the process board, not a product feature. See `docs/github.md`. Repo: https://github.com/sebbeflebbe/penumbra Board: https://github.com/users/sebbeflebbe/projects/2
+GitHub is the process board, not a product feature. See `docs/github.md`. Four-week enhancement spec: `docs/roadmap.md`. Repo: https://github.com/sebbeflebbe/penumbra Board: https://github.com/users/sebbeflebbe/projects/2
 
 1. Before coding a slice: create or pick the issue; add `status:in-progress` (Project: **In Progress**).
 2. When the slice lands: comment with what changed; close the issue (Project: **Done**). PRs use `Fixes #N`.
 3. Do not let the board rot.
 
 Use `gh issue` / `gh project`, not Atlassian.
+
+## Versioning and PRs
+
+Never commit on `main`. See `docs/versioning.md`.
+
+1. Create `{major|minor|patch}/vX.Y.Z-{slug}` from up-to-date `main`.
+2. Bump `pubspec.yaml` to match (`MAJOR.MINOR.PATCH+BUILD`).
+3. Commit, `git push -u origin HEAD`, open a PR to `main`. PR title starts with `vX.Y.Z:`.
+4. Merge only when CI jobs **analyze**, **test**, **build-web**, and **supply-chain** are green.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create the project in **eu-central-1 (Frankfurt)**. Apply `supabase/migrations/`
 
 ## Auth
 
-Passkeys, Google, GitHub, magic link, and password (12+ characters). Passkeys are first in the layout. OAuth users receive a 12-word recovery phrase once — that phrase wraps the data-encryption key when there is no password.
+Passkeys, Google, GitHub, magic link, and password (12+ characters). Passkeys are first in the layout. On a configured Supabase project they use WebAuthn (`auth.passkey`); enable Passkeys in the Frankfurt Auth settings and set `PENUMBRA_ORIGIN` to the exact HTTPS origin (or localhost) or the ceremony will fail. The in-memory demo still fakes a passkey session. OAuth users receive a 12-word recovery phrase once — that phrase wraps the data-encryption key when there is no password. WebAuthn PRF wrapping is not assumed.
 
 ## GDPR and cybersecurity (honest scope)
 

--- a/docs/accessibility/statement.md
+++ b/docs/accessibility/statement.md
@@ -2,4 +2,4 @@
 
 See `/legal/accessibility` in the running app. Source of this statement: `lib/features/legal/presentation/legal_catalog.dart`.
 Date: 2026-09-05.
-Conformance: partial, targeting WCAG 2.1 AA via EN 301 549 web chapter. The European Accessibility Act applies from 28 June 2025; we do not claim full Act conformance. Known gap: Flutter web semantics overlay.
+Conformance: partial, targeting WCAG 2.1 AA via EN 301 549 web chapter. The European Accessibility Act applies from 28 June 2025; we do not claim full Act conformance. Known gaps: Flutter web semantics overlay; InteractiveViewer is not a spatial map in the accessibility tree (Index + named Move handle are the mitigation).

--- a/docs/adr/001-stack.md
+++ b/docs/adr/001-stack.md
@@ -2,7 +2,10 @@
 
 Status: accepted
 Date: 2026-08-31
+Amended: 2026-09-05
 
-Use Flutter web + Forui 0.22.2 + Riverpod + an in-memory studio that mirrors a future Supabase Frankfurt backend, hosted on Cloudflare Pages.
+Use Flutter web + Forui 0.22.2 + Riverpod + an in-memory studio that mirrors the live Supabase Frankfurt backend, hosted on Cloudflare Pages.
+
+The in-memory studio is the default for tests and reviewers. The same contracts hit Supabase when both `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set. CI stays on Flutter 3.44.1.
 
 Rejected Firebase as the primary GDPR story (less portable, weaker EU narrative). Rejected latest Forui 0.26 because it requires Flutter 3.47.

--- a/docs/adr/002-key-wrapping.md
+++ b/docs/adr/002-key-wrapping.md
@@ -3,6 +3,6 @@
 Status: accepted
 Date: 2026-08-31
 
-Password users wrap the DEK with Argon2id(password). OAuth and passkey users wrap with a 12-word BIP39-style phrase shown once. WebAuthn PRF is the future preferred wrap for passkeys and is not assumed available.
+Password users wrap the DEK with Argon2id(password). OAuth and passkey users wrap with a 12-word BIP39-style phrase shown once. Cloud passkeys use Supabase Auth WebAuthn (`auth.passkey`) plus the browser ceremony; the wrap is still the recovery phrase. WebAuthn PRF is the future preferred wrap for passkeys and is not assumed available.
 
 Rejected storing a plaintext DEK server-side. Rejected pretending social login is zero-knowledge without a recovery secret.

--- a/docs/github.md
+++ b/docs/github.md
@@ -11,7 +11,17 @@ Issues:
 - https://github.com/sebbeflebbe/penumbra/issues/2 Canvas echo ritual (Done)
 - https://github.com/sebbeflebbe/penumbra/issues/3 Cloud: wire Supabase (Done)
 - https://github.com/sebbeflebbe/penumbra/issues/4 A11y: themes + EAA copy (Done)
-- https://github.com/sebbeflebbe/penumbra/issues/5 Process: GitHub Project instead of Jira
+- https://github.com/sebbeflebbe/penumbra/issues/5 Process: GitHub Project instead of Jira (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/6 Edit and delete human slips (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/7 Drag-move slips + acknowledge recovery phrase (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/8 Board rename, delete, Art. 18 restrict (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/9 Persist remote-echo consent + erase re-auth (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/10 Cloud WebAuthn passkeys (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/11 Unavailable-path tests + honest copy (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/12 A11y lockstep after new controls (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/13 Env/imprint/ADR/story/OSV hygiene (Done)
+
+Four-week spec: [roadmap.md](roadmap.md). Versioning and GitHub Flow: [versioning.md](versioning.md).
 
 ## Ritual
 
@@ -22,6 +32,7 @@ Issues:
 ## Labels
 
 - `status:in-progress` — this chat (or a PR) is working the slice.
+- `week-1` … `week-4` — four-week enhancement slices.
 
 Opened issues land in **Todo**. Closed issues land in **Done**. `.github/workflows/project.yml` keeps the Project Status field in sync when `PROJECTS_TOKEN` and `PENUMBRA_PROJECT_NUMBER` are set.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,349 @@
+# Penumbra four-week enhancement roadmap
+
+Canonical spec for GitHub Issues #6–#13. Development board: [docs/github.md](github.md). Principles: [AGENTS.md](../AGENTS.md).
+
+This is process, not a product feature. No in-studio Kanban.
+
+Stay inside [AGENTS.md](../AGENTS.md): one ritual, cloud real when configured, passkeys first, EN 301 549 bar, TDD, making-of in lockstep. No in-studio Kanban, sharing, or extra dashboards.
+
+
+```mermaid
+flowchart LR
+  capture[Docs_and_Issues] --> w1[Week1_Canvas]
+  w1 --> w2[Week2_Rights]
+  w2 --> w3[Week3_Passkeys]
+  w3 --> w4[Week4_Honesty]
+```
+
+## Frozen constraints (every week)
+
+- **Do not bump Forui.** Pinned at `forui: 0.22.2` because 0.26 needs Flutter 3.47 ([docs/adr/001-stack.md](docs/adr/001-stack.md)). CI is `FLUTTER_VERSION: "3.44.1"` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+- **Do not bump Flutter** in CI unless a CVE forces it; if you must, re-evaluate Forui (likely blocked).
+- Domain has no Flutter and no Supabase. Tests use [InMemoryStudio](lib/features/studio/in_memory_studio.dart). CI never gets `SUPABASE_*` dart-defines.
+- Card bodies stay AES-256-GCM in the browser. Echoes still send **one slip** after Art. 6(1)(a), or local ([docs/adr/007-echo.md](docs/adr/007-echo.md)).
+- Honesty: no CE / NIS2 entity / ISO 27001 / full EAA claims.
+
+## Current versions (baseline)
+
+- App: `1.0.0+1` in [pubspec.yaml](pubspec.yaml)
+- SDK: `^3.12.1`; Flutter CI `3.44.1`
+- Notable deps: `forui 0.22.2`, `flutter_riverpod ^2.6.1`, `go_router ^15.1.2`, `cryptography ^2.7.0`, `supabase_flutter ^2.9.0`, `web ^1.1.1`, `flutter_lints ^6.0.0`
+- App version stays `1.0.0+1` through Weeks 1–3; Week 4 bumps to **`1.1.0+2`** once the ritual UI matches the domain.
+
+## Known code facts the issues must name
+
+- Canvas UI is one ~1067-line file: [lib/features/canvas/presentation/canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart). Extract when touching it; do not grow it blindly.
+- `CanvasRepository.delete` already exists and **cascades child echoes** in both studios. UI only calls it from `_dismissEcho`.
+- `deleteNode` in memory ([in_memory_studio.dart](lib/features/studio/in_memory_studio.dart) ~471) and cloud ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~448) **does not check `board.restricted`**. `upsert` does. Exposing human-delete without that check breaks Art. 18.
+- `_nudge` already moves a parent’s echo by the same delta (~163–186) but **swallows** upsert errors (`err: (_) {}`). Restricted boards fail silently today.
+- Recovery phrase `FAlert` is shown when `pendingRecoveryPhrase != null` (~431–438) but nothing calls `acknowledgeRecoveryPhrase()`.
+- Echo consent is a canvas field `_echoConsentedThisSession`. `ConsentKind` is only `necessaryStorage | termsOfUse`. Table `consent_events.kind` is unconstrained `text` ([0001_init.sql](supabase/migrations/0001_init.sql)); no SQL enum migration required.
+- Privacy erase UI calls `eraseAccount()` with **no password** ([privacy_page.dart](lib/features/privacy/presentation/privacy_page.dart) ~40). Studio contract already requires the password ([studio_contract_test.dart](test/features/studio_contract_test.dart) ~115).
+- Cloud passkeys always `AuthUnavailableFailure` ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~177–189). In-memory fakes a session as `passkey-ada@penumbra.studio`.
+- `.env.example` still has `LUMEN_*`; [config.dart](lib/core/config.dart) already reads `PENUMBRA_*`.
+
+---
+
+## Week 1 — Finish the canvas ritual
+
+**Goal:** Place is not write-only. Keep Index, hairlines, and encryption behaviour identical.
+
+### Issue #6 — Edit and delete human slips
+
+**Why.** `_PaperSlip` only offers Dismiss for echoes. Humans can Place forever and never correct a typo. `CanvasRepository.delete` and echo cascade are already implemented.
+
+**Acceptance**
+
+- Selected **text** (and **swatch**) slips expose named controls: **Edit** (text only), **Delete**. Echoes stay Dismiss-only; echo body is not editable.
+- Edit: in-place field or compose-bar reuse; empty body refused; `upsert` re-encrypts the full payload (`toPayload()` already includes `text`/`x`/`y`/`parentId`).
+- Delete human: confirm dialog with named buttons (not an icon-only trash). Studio cascade removes the child echo; UI drops both from `_nodes` and repairs `_focusedIndex`. Index numerals update via `EchoPairing.conversation`.
+- Restricted board: delete and edit must `ForbiddenFailure` and `announce` the Art. 18 message. Domain test first: `deleteNode` on a restricted board is `ForbiddenFailure` (this is a **new** studio check, both implementations).
+- 48px-class targets; Semantics labels (`Edit this note`, `Delete this note`). High-contrast: no extra shadow; reduced motion: no extra animation ([motion.dart](lib/core/a11y/motion.dart)).
+
+**Implementation**
+
+- Add `restricted` check to `deleteNode` in both studios (mirror `upsert`).
+- Extract `_PaperSlip` (+ edit state) out of `canvas_page.dart` if the file would grow; prefer `lib/features/canvas/presentation/paper_slip.dart`.
+- `_ComposeBar`: when a text slip is selected, Place can become Save, or keep Place and add Edit on the slip. Prefer slip-local edit so Index/canvas stay one ritual.
+- Do not add a properties panel.
+
+**Files**
+
+- [lib/features/studio/in_memory_studio.dart](lib/features/studio/in_memory_studio.dart), [lib/features/studio/supabase_studio.dart](lib/features/studio/supabase_studio.dart) (`deleteNode`)
+- [lib/features/canvas/presentation/canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart), likely new `paper_slip.dart`
+- [test/features/studio_contract_test.dart](test/features/studio_contract_test.dart)
+- New `test/features/canvas/slip_edit_delete_test.dart` (widget, pattern from [echo_ritual_test.dart](test/features/canvas/echo_ritual_test.dart): `pumpStudio`, disable animations, 1400×900)
+
+**Tests (write first)**
+
+- Domain: delete human with echo → both gone; ciphertext gone from `debugCipherStorage`.
+- Domain: restricted `deleteNode` → `ForbiddenFailure`.
+- Widget: Enter studio → Open → select seeded “Private by default.” → Delete → confirm → text gone; Index no longer lists it.
+- Widget: Edit that slip → Save → Index shows new text; `semanticsLabel` follows `BoardNode.semanticsLabel`.
+
+**Difficulties**
+
+- `canvas_page.dart` size and private widgets (`_PaperSlip`, `_Atelier`). Extraction will churn diffs; keep visual parity (borders, Fraunces numerals, copper selected state).
+- Widget tests that tap slips inside `InteractiveViewer` are fragile (see existing `find.text('Private by default.').first`). Prefer `ensureVisible` + first match; set `disableAnimations`.
+- Confirm dialog: Forui `showFDialog` already used for echo consent — reuse that pattern, not `AlertDialog`.
+- Do not decrypt in the UI; only call `upsert`/`delete`.
+
+**Deps / bumps.** None.
+
+**Docs.** One paragraph in chapter 03 or 09 that Place is reversible. No ADR unless delete-on-restricted behaviour was undocumented (it was a hole).
+
+**Out of scope.** Drag (issue #7). Echo body edit. Rich text.
+
+### Issue #7 — Drag-move slips + acknowledge recovery phrase
+
+**Why.** Arrow keys already persist via `_nudge` (16px). Pointer users cannot move. Recovery phrase alert never clears `needsRecoveryPhraseReveal`, so it can haunt the chrome forever.
+
+**Acceptance**
+
+- Pointer drag on a focused slip persists `x`/`y` through `upsert`. Keyboard nudge still works.
+- Dragging a **text** parent moves its echo by the same delta (copy `_nudge` ~174–183). Then run existing `_untangleEchoes` if overlap.
+- `InteractiveViewer` pan/zoom still works on empty sheet; drag on a slip must not pan the viewport (gesture conflict is the hard part).
+- Reduced motion: drag still works; skip `penumbraCardAppear` extras only.
+- Recovery phrase alert gains a named button **I have saved this phrase** → `acknowledgeRecoveryPhrase()`; phrase disappears; in-memory test already covers the API ([studio_contract_test.dart](test/features/studio_contract_test.dart) ~42–48).
+
+**Implementation**
+
+- Prefer a **Move** affordance on the selected slip (named, 48px) that captures pointer, rather than making the whole slip a `PanGesture` (that fights selection and InteractiveViewer). Alternative: `Listener` on the slip that sets `InteractiveViewer.panEnabled: false` while dragging.
+- Snap optional: 8px grid to match 16px nudge; if snap, document it. Default: free drag, keyboard stays 16px.
+- After pointer-up, `announce` “Moved” for SR users.
+- Pass `onAcknowledgePhrase` from `_CanvasPageState` into `_Atelier`.
+
+**Files**
+
+- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart) (`_nudge`, `_Atelier`, `InteractiveViewer` ~469)
+- [auth_models.dart](lib/features/auth/domain/auth_models.dart) (already has the method)
+- New widget test in `slip_edit_delete_test.dart` or `recovery_phrase_ack_test.dart`
+
+**Tests**
+
+- Widget: OAuth/passkey path in memory — GitHub sign-in is awkward in widget tests; easier to `enterDemoStudio` is wrong (demo has no phrase). Prefer a unit/widget with `InMemoryStudio.signInWithGitHub()` then pump `/boards/...`. If too heavy, a focused test that pumps canvas with a fake auth repo exposing `pendingRecoveryPhrase`.
+- Drag: if widget gesture vs InteractiveViewer is too flaky in CI, extract `BoardNode movedBy(BoardNode node, double dx, double dy, {BoardNode? echo})` in domain (pure) and test that; keep one smoke widget test.
+
+**Difficulties**
+
+- **Highest Week-1 risk:** `InteractiveViewer` vs child `GestureDetector` arena. If pan steals the drag, users cannot move. If slip steals pan, the sheet cannot be explored. Must toggle `panEnabled` or use a dedicated handle.
+- `_nudge` swallowing errors: while here, `announce` on `ForbiddenFailure` so Week 2 restrict UX is not silent.
+- Flutter web pointer vs trackpad pinch — don’t disable scale (`minScale`/`maxScale` stay 0.5–2.5).
+
+**Deps / bumps.** None.
+
+**Out of scope.** Multi-select, alignment guides, undo stack.
+
+---
+
+## Week 2 — Board lifecycle and consent honesty
+
+**Goal.** Legal copy already promises rename, Art. 18 restrict, export, erase. Domain already implements them. UI does not.
+
+### Issue #8 — Board rename, delete, Art. 18 restrict
+
+**Why.** [boards_page.dart](lib/features/boards/presentation/boards_page.dart) create+list only. Restricted is a badge (`board.restricted ? 'Restricted'` ~183). [BoardRepository](lib/features/boards/domain/board_repository.dart) already has `rename` / `delete` / `setRestricted`. Canvas compose bar does not know about restricted.
+
+**Acceptance**
+
+- Each board row: **Rename**, **Restrict** / **Unrestrict**, **Delete** (confirm). Named controls, 48px-class.
+- Restrict → studios refuse `upsert`/`deleteNode` (after #6) → canvas shows a persistent `FAlert` and disables Place / Swatch / Summon / Edit / Delete / drag.
+- Delete board: confirm; navigate away if the open canvas was that id (`go_router` `/boards`).
+- Rename updates chrome title on next load (`PenumbraChrome title: _board!.title`).
+- Widget test: restrict seeded board → Open → Place is absent or disabled; announce/alert contains `Art. 18`.
+
+**Implementation**
+
+- Boards page uses `FutureBuilder` once; keep `_boards` local mutations like `_create` already does.
+- Canvas: `if (_board!.restricted)` short-circuit `_addNote` / `_addSwatch` / `_summonEcho` / `_nudge` / drag.
+- Do not add a settings route; keep actions on the boards list (UX depth over chrome).
+
+**Files**
+
+- [boards_page.dart](lib/features/boards/presentation/boards_page.dart)
+- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart)
+- New `test/features/boards/board_lifecycle_test.dart`
+- Existing domain test `restricted boards refuse writes` stays; extend with delete.
+
+**Difficulties**
+
+- `FutureBuilder` will not refetch after rename if we only mutate `_boards` — that’s fine if we update local state.
+- Cloud delete is RLS-owned; in-memory must match ([in_memory_studio.dart](lib/features/studio/in_memory_studio.dart) `delete`).
+- Restricted **read** still allowed (export/privacy). Don’t hide the board.
+
+**Deps / bumps.** None.
+
+**Docs.** [legal_catalog.dart](lib/features/legal/presentation/legal_catalog.dart) already mentions Art. 18; no copy change unless the UI label differs. Touch [docs/privacy/policy.md](docs/privacy/policy.md) only if the flow changes.
+
+### Issue #9 — Persist remote-echo consent + erase re-auth
+
+**Why.** Remote Gemini path sets a session bool. Refresh = consent again (honest-ish) but export never shows `remoteEcho`. Erase button ignores `eraseAccount({password})`.
+
+**Acceptance**
+
+- Add `ConsentKind.remoteEcho`. `recordConsent` on agree in `_confirmRemoteEcho`. Later summons in this session skip the dialog if a granted event exists; **revocation** is not required this week (no “withdraw echo consent” UI), but a new session should still confirm unless a granted row exists (persisted = skip dialog). Choose **persist across sessions** (true Art. 6(1)(a) record) and document that withdraw is Week-4-or-later if time is gone.
+- `_consentKind` unknown-name fallback today maps to `necessaryStorage` ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~830). New enum value must parse `remoteEcho`; unknown stays fallback.
+- Export JSON includes the new kind. [penumbraDataCategories](lib/features/privacy/domain/privacy_models.dart) already has “Optional echo (Gemini)”.
+- Privacy page: password field (12+) for password users; for OAuth, copy that they must have signed in within 5 minutes (`reauthenticate` cloud branch ~227–230). Destructive Erase stays disabled until that is satisfied. Wrong password keeps the account ([studio_contract_test](test/features/studio_contract_test.dart)).
+- After erase success, `go` landing / sign-in; don’t leave a dead `/privacy` session.
+
+**Implementation**
+
+- Canvas should call `privacyRepositoryProvider.recordConsent(ConsentKind.remoteEcho, granted: true)` — **do not** send the slip text to that API.
+- No new SQL migration (kind is `text`). Optional `0004` only if we add a check constraint; skip unless we want DB-level enum (prefer skip — Dart is source of truth).
+- Local composer (`composer.remote == false`) never records `remoteEcho`.
+
+**Files**
+
+- [privacy_models.dart](lib/features/privacy/domain/privacy_models.dart), both studios `recordConsent` / `_consentKind`
+- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart), [privacy_page.dart](lib/features/privacy/presentation/privacy_page.dart)
+- [echo_ritual_test.dart](test/features/canvas/echo_ritual_test.dart) — today uses `LocalEchoComposer` so it **must not** require the dialog. Add a test with a fake `remote: true` composer that asserts the dialog copy (`Google LLC`, `Art. 6(1)(a)`) then records consent.
+
+**Difficulties**
+
+- Widget test for **remote** composer needs a fake `EchoComposer` with `remote == true` that does not hit Gemini. The production Gemini path needs `GEMINI_API_KEY`; CI has none.
+- OAuth re-auth window is 5 minutes in cloud studio — document in UI; don’t invent a second OAuth popup this week.
+- Enum addition is a breaking serialization change only if old clients see `remoteEcho` and fall back to `necessaryStorage` (misleading in export). Ship enum + parser together.
+
+**Deps / bumps.** None.
+
+---
+
+## Week 3 — Passkeys that match the sign-in page
+
+**Goal.** “Passkeys first” in [sign_in_page.dart](lib/features/auth/presentation/sign_in_page.dart) (~107) must not be a lie on Supabase.
+
+### Issue #10 — Cloud WebAuthn passkeys (no PRF required)
+
+**Why.** `signInWithPasskey` / `registerPasskey` on [SupabaseStudio](lib/features/studio/supabase_studio.dart) hard-return unavailable. ADR-002: wrap DEK with 12-word phrase until PRF exists. In-memory stays a **demo fake**.
+
+**Acceptance**
+
+- Cloud: `navigator.credentials` / `package:web` (already a dep) or `supabase_flutter` Auth WebAuthn API if present in 2.9+. If the plugin in 2.9 cannot do it, bump **`supabase_flutter` within 2.x only** (see bumps). Do not add a second auth SDK.
+- Happy path (HTTPS or localhost, platform authenticator): register or sign in; session DEK still wrapped with recovery phrase on first passkey/OAuth user; phrase UI from #7 still applies.
+- Missing WebAuthn, HTTP non-localhost, user abort: `AuthCancelledFailure` or `AuthUnavailableFailure` with honest copy. Button stays first in the layout. **No silent fallback to password.**
+- RP ID = host of `PENUMBRA_ORIGIN` ([config.dart](lib/core/config.dart)). Cloudflare Pages deploy must use that origin; mismatch = passkeys fail. Document in README.
+- `AuthMethod.passkey` already mapped from `'webauthn'` (~812). Keep that.
+
+**Implementation order**
+
+1. Spike: read `supabase_flutter` 2.9 Auth API for `signInWithWebauthn` / `getAuthenticatorAssuranceLevel`. If absent, check latest 2.x changelog **before** coding UI.
+2. Implement behind `StudioMode.supabase` only.
+3. Keep in-memory `signInWithPasskey` as fake (tests depend on it: [studio_contract_test.dart](test/features/studio_contract_test.dart) ~31).
+
+**Files**
+
+- [supabase_studio.dart](lib/features/studio/supabase_studio.dart), [sign_in_page.dart](lib/features/auth/presentation/sign_in_page.dart) (busy/error copy only)
+- [docs/adr/002-key-wrapping.md](docs/adr/002-key-wrapping.md) — note “cloud WebAuthn shipped; PRF still future”
+- [docs/story/02-auth.md](docs/story/02-auth.md) + catalog chapter 02 — “cloud passkeys are WebAuthn; demo studio still fakes”
+- README Auth section
+
+**Tests**
+
+- No live authenticator in CI. Unit-test a small wrapper with a fake `WebAuthnGateway`: success, abort, unsupported.
+- Existing in-memory passkey test **must remain green**.
+
+**Difficulties (this is the hardest week)**
+
+- Flutter web WebAuthn is poorly documented; `package:web` `CredentialsContainer` vs js-interop breakage across compilers.
+- Supabase project must enable WebAuthn in Auth settings (manual console step — cannot be done from this repo alone). Issue must list: **operator step** on the Frankfurt project.
+- Conditional UI / autofill passkeys: skip.
+- Cross-device QR passkeys: skip.
+- Safari vs Chromium PRF: **out of scope** (stretch below).
+- Relying party ID vs `*.pages.dev` vs custom domain — getting this wrong looks like “passkeys broken”.
+- Don’t store DEK server-side if the wrap path is painful. Recovery phrase remains the wrap.
+
+**Deps / bumps**
+
+- Allowed: `supabase_flutter` `^2.9.0` → latest compatible 2.x if required for WebAuthn. Re-run `flutter pub get` and CI OSV.
+- Allowed: tiny helper only if supabase_flutter still has no API — prefer `package:web` already in pubspec, not a new `passkeys` plugin (those are often mobile-first).
+- Forbidden: Forui bump, Flutter 3.47, Firebase Auth.
+
+**Stretch (only if #10 lands before Wednesday):** WebAuthn PRF extension wraps DEK instead of recovery phrase when `prf` is in `getClientCapabilities`. If unsupported, keep phrase. Do not ship a half-PRF that drops keys.
+
+### Issue #11 — Unavailable-path tests + honest copy
+
+**Why.** Even after #10, many reviewers will run in-memory or HTTP. The button must explain why.
+
+**Acceptance**
+
+- Cloud without WebAuthn: existing `AuthUnavailableFailure` message, maybe tightened: “This browser cannot create a passkey. Use Google, GitHub, a magic link, or a password.”
+- In-memory: keep working fake; making-of says so.
+- [app_widget_test.dart](test/app/app_widget_test.dart) still finds `Continue with a passkey`.
+- Sign-in errors go to `FAlert` (`_error`), not a snackbar.
+
+**Files.** Sign-in page, supabase studio, story 02, ADR-002, new `test/features/auth/passkey_unavailable_test.dart` with a fake studio.
+
+**Difficulties.** Don’t make in-memory start returning unavailable — that would break studio_contract and the demo.
+
+**Deps / bumps.** None beyond #10.
+
+---
+
+## Week 4 — Honesty pass
+
+**Goal.** Binary, making-of, env names, and a11y statement agree. App version `1.1.0+2`.
+
+### Issue #12 — A11y lockstep after new controls
+
+**Why.** Weeks 1–2 add Edit/Delete/Move/Restrict. Statement still only mentions Flutter web semantics overlay ([docs/accessibility/statement.md](docs/accessibility/statement.md), [legal_catalog.dart](lib/features/legal/presentation/legal_catalog.dart)).
+
+**Acceptance**
+
+- Every new control has a Semantics name; destructive confirms are keyboard reachable.
+- High-contrast theme: new buttons still true B/W ([theme.dart](lib/app/theme.dart)). Zinc light/dark: spot-check `mutedForeground` on `paper`/`darkPaper` — if below AA for helper text, darken `PenumbraInk.mute` (`0xFF6F675C`) rather than inventing a fifth theme.
+- Statement date bump; list **new** known gaps (InteractiveViewer not in the accessibility tree as a canvas map; drag handle as the mitigation). Still **no full EAA claim**.
+- Widget: summon consent dialog has titled actions (extend echo_ritual with remote fake from #9 if not already).
+
+**Difficulties.** Flutter web semantics overlay will remain; don’t pretend a package bump fixes it. Don’t bump Forui for “better a11y” (Flutter 3.47 trap).
+
+**Deps / bumps.** None required. If `flutter_lints` flags new files, fix code not the linter version unless OSV says so.
+
+### Issue #13 — Env/imprint/ADR/story/OSV hygiene
+
+**Why.** `.env.example` still `LUMEN_*`. ADR-001 still says in-memory mirrors a **future** Supabase. Story chapter 08 is the last shipped chapter. OSV runs on every CI.
+
+**Acceptance**
+
+- [.env.example](.env.example) uses `PENUMBRA_CONTROLLER_NAME`, `PENUMBRA_CONTROLLER_EMAIL`, `PENUMBRA_ORIGIN` matching [config.dart](lib/core/config.dart). Placeholders stay `.invalid`.
+- ADR-001: in-memory **mirrors the live** Frankfurt studio; Forui 0.22.2 / Flutter 3.44 pin restated.
+- Chapter 09 rewritten as retrospective of Weeks 1–4 (what shipped, what stayed fake: in-memory OAuth/passkey/magic, PRF wrap).
+- `pubspec.yaml` version **1.1.0+2**.
+- `flutter pub upgrade` **without** major Forui. If OSV fails, patch the offending package only. Commit `pubspec.lock`.
+- CI still `FLUTTER_VERSION: 3.44.1` unless a CVE in the engine forces a pin change (then re-validate Forui).
+
+**Files.** `.env.example`, `docs/adr/001-stack.md`, story catalog + `docs/story/09-roadmap.md`, `pubspec.yaml` / `pubspec.lock`, README dart-define block, possibly [docs/compliance/processors.md](docs/compliance/processors.md) if WebAuthn/Google paths changed wording.
+
+**Difficulties**
+
+- `flutter pub upgrade` can drag `go_router` 15.x or `riverpod` 2.x minors — run full `flutter test` + `dart analyze --fatal-warnings`.
+- Don’t “fix” controller email to a real inbox in-repo.
+
+**Deps / bumps (allowed in #13)**
+
+- Patch/minor: `cryptography`, `http`, `shared_preferences`, `uuid`, `intl`, `supabase_flutter` (if not already bumped in #10), `url_launcher`
+- Forbidden: `forui` 0.23+, Flutter 3.47+, adding Google Fonts runtime
+
+---
+
+## GitHub issue bodies (paste as-is)
+
+Each issue uses this skeleton; fill from the sections above:
+
+- Title: as in `#6`–`#13` headings
+- Labels: `week-N`
+- Body sections: **Why** · **Acceptance** · **Implementation** · **Files** · **Tests (TDD first)** · **Difficulties** · **Deps / bumps** · **Docs** · **Out of scope**
+
+Do not open empty issues and “fill later”. The board is the interview process artifact.
+
+## What we will not schedule
+
+- In-studio process boards, sharing, multiplayer, mobile, extra model vendors
+- CE / NIS2 / ISO / full EAA claims
+- Supabase integration tests in CI
+- Forui 0.26 / Flutter 3.47
+- WebAuthn PRF as a committed deliverable (stretch on #10 only)
+
+## Cadence
+
+Each coding week: failing domain test → studio both paths → UI → widget test → making-of/ADR touch → `gh issue close`. Reviewers keep using **Enter the studio** (in-memory). Cloud checks need both `SUPABASE_*` dart-defines plus, for Week 3, WebAuthn enabled on the Frankfurt project.

--- a/docs/story/02-auth.md
+++ b/docs/story/02-auth.md
@@ -1,5 +1,5 @@
 # Chapter 02 — Auth
 
-Methods: passkey, Google, GitHub, magic link, password. Passkeys lead the layout (eIDAS 2 / WebAuthn). Passwords are last and must be twelve characters.
+Methods: passkey, Google, GitHub, magic link, password. Passkeys lead the layout (eIDAS 2 / WebAuthn). On the cloud path they are real WebAuthn against Supabase Auth (`auth.passkey`); the relying party ID must match `PENUMBRA_ORIGIN`. The in-memory studio still fakes a passkey session. Passwords are last and must be twelve characters.
 
-OAuth identity providers are independent controllers. OAuth and passkey users receive a twelve-word recovery phrase to wrap the DEK when WebAuthn PRF is unavailable. That tradeoff is documented rather than hidden.
+OAuth identity providers are independent controllers. OAuth and passkey users receive a twelve-word recovery phrase to wrap the DEK when WebAuthn PRF is unavailable. That tradeoff is documented rather than hidden. Enable Passkeys in the Frankfurt Supabase Auth settings or the button fails honestly.

--- a/docs/story/03-canvas.md
+++ b/docs/story/03-canvas.md
@@ -1,5 +1,5 @@
 # Chapter 03 — Canvas and crypto
 
-Cards are widgets so they exist in the semantics tree. A list provides document order. Arrow keys nudge the focused card.
+Cards are widgets so they exist in the semantics tree. A list provides document order. Arrow keys or a named Move handle reposition the focused card. Human slips can be edited and deleted; deleting a parent also removes its echo.
 
-Payloads are AES-256-GCM. Tests assert stored ciphertext does not contain plaintext, and that a second user cannot read a board (RLS contract). Restricted boards refuse writes (Art. 18).
+Payloads are AES-256-GCM. Tests assert stored ciphertext does not contain plaintext, and that a second user cannot read a board (RLS contract). Restricted boards refuse writes, including delete (Art. 18).

--- a/docs/story/09-roadmap.md
+++ b/docs/story/09-roadmap.md
@@ -1,0 +1,9 @@
+# Chapter 09 — The four-week deepening
+
+The studio already had a ritual. Four weeks deepened it rather than adding chrome.
+
+Place is reversible: edit, delete (with cascade), and a Move handle that yields the sheet pan while dragging. Recovery phrases can be acknowledged. Boards expose rename, delete, and Art. 18 restrict in the list the legal copy already promised. Remote echoes persist Art. 6(1)(a) consent. Erasure asks for the password the studio always required.
+
+Cloud passkeys call Supabase Auth WebAuthn plus the browser ceremony. The in-memory studio still fakes passkey, Google, GitHub, and magic link so CI never needs secrets. The DEK wrap for passkeys remains the twelve-word phrase; WebAuthn PRF is still future work.
+
+The plan is `docs/roadmap.md`. Issues #6–#13 are the board. This chapter is the retrospective, not a promise of work still undone.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,54 @@
+# Versioning and GitHub Flow
+
+Penumbra follows [SemVer 2.0](https://semver.org/) and **GitHub Flow**: short-lived branches, pull request into `main`, no `develop` branch and no long-lived `release/*` trains.
+
+The product version lives only in `pubspec.yaml` as Flutter expects: `MAJOR.MINOR.PATCH+BUILD`.
+
+## When to bump
+
+- **MAJOR** — breaking privacy, auth, or storage contract (encryption, fail-closed config, session / DEK wrap, RLS meaning).
+- **MINOR** — user-visible capability (new ritual, rights UI, cloud passkeys).
+- **PATCH** — fix, copy, accessibility, CI, or docs that do not add capability.
+- **+BUILD** — increment on every versioned PR. Never reuse a build number.
+
+Do not bump Forui or Flutter as a side effect of a product bump (ADR-001: Forui 0.22.2, CI Flutter 3.44.1).
+
+## Branch naming
+
+```
+{bump}/v{MAJOR}.{MINOR}.{PATCH}-{slug}
+```
+
+`{bump}` is `major`, `minor`, or `patch` and **must match** the pubspec bump on that branch. `{slug}` is lowercase kebab-case and names one concern.
+
+Examples:
+
+- `minor/v1.1.0-ritual-deepening`
+- `patch/v1.1.1-passkey-copy`
+
+Same name locally and on `origin`. PR title starts with `vX.Y.Z:`.
+
+## Agent ritual
+
+1. Never commit on `main`. Create the versioned branch from up-to-date `main` **before** editing.
+2. First change on the branch includes the `pubspec.yaml` bump.
+3. Commit, then `git push -u origin HEAD`.
+4. Open a PR to `main` (`gh pr create --base main`). Use `Fixes #N` only when an issue is still open.
+5. Do not merge until CI is green: **analyze**, **test**, **build-web**, **supply-chain**. Deploy runs on `main` only.
+
+## CI gates
+
+Pull requests and `main` run four required jobs (see `.github/workflows/ci.yml`):
+
+- **analyze** — `dart analyze --fatal-warnings`
+- **test** — `flutter test --coverage` (in-memory studio; no Supabase secrets)
+- **build-web** — `flutter build web --release` (proves the interview artifact ships)
+- **supply-chain** — CycloneDX SBOM + OSV on `pubspec.lock`
+
+**deploy** is not a PR gate. It runs on `main` only when `CLOUDFLARE_PROJECT_NAME` is set.
+
+Repo settings (manual): require those four checks on `main`; disallow direct pushes if branch protection is available.
+
+## Out of scope here
+
+GitFlow release trains. Live Supabase or WebAuthn in CI. Auto-tagging (`vX.Y.Z` after merge is optional later).

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -13,17 +13,23 @@ class PenumbraApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final appearance = ref.watch(appearanceProvider);
-    final platform = WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    final platform =
+        WidgetsBinding.instance.platformDispatcher.platformBrightness;
     final pair = PenumbraThemes.pair(appearance, platform);
     final light = pair.$1;
-    final dark = appearance == PenumbraAppearance.dark || (appearance == PenumbraAppearance.system && platform == Brightness.dark)
+    final dark =
+        appearance == PenumbraAppearance.dark ||
+            (appearance == PenumbraAppearance.system &&
+                platform == Brightness.dark)
         ? pair.$2
         : pair.$1;
     final active = switch (appearance) {
       PenumbraAppearance.dark => dark,
-      PenumbraAppearance.highContrast when platform == Brightness.dark => PenumbraThemes.highContrastDark(),
+      PenumbraAppearance.highContrast when platform == Brightness.dark =>
+        PenumbraThemes.highContrastDark(),
       PenumbraAppearance.highContrast => PenumbraThemes.highContrastLight(),
-      PenumbraAppearance.system when platform == Brightness.dark => PenumbraThemes.dark(),
+      PenumbraAppearance.system when platform == Brightness.dark =>
+        PenumbraThemes.dark(),
       _ => light,
     };
 
@@ -43,10 +49,7 @@ class PenumbraApp extends ConsumerWidget {
       routerConfig: router,
       builder: (context, child) {
         return FToaster(
-          child: FTheme(
-            data: active,
-            child: child ?? const SizedBox.shrink(),
-          ),
+          child: FTheme(data: active, child: child ?? const SizedBox.shrink()),
         );
       },
     );

--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -14,13 +14,17 @@ import '../features/studio/in_memory_studio.dart';
 import '../features/studio/studio_repositories.dart';
 import 'theme.dart';
 
-final configProvider = Provider<PenumbraConfig>((ref) => PenumbraConfig.fromEnvironment());
+final configProvider = Provider<PenumbraConfig>(
+  (ref) => PenumbraConfig.fromEnvironment(),
+);
 
 final studioProvider = Provider<InMemoryStudio>((ref) {
   throw StateError('studioProvider must be overridden in bootstrap.');
 });
 
-final authRepositoryProvider = Provider<AuthRepository>((ref) => ref.watch(studioProvider));
+final authRepositoryProvider = Provider<AuthRepository>(
+  (ref) => ref.watch(studioProvider),
+);
 
 final boardRepositoryProvider = Provider<BoardRepository>(
   (ref) => InMemoryBoardRepository(ref.watch(studioProvider)),
@@ -30,7 +34,9 @@ final canvasRepositoryProvider = Provider<CanvasRepository>(
   (ref) => InMemoryCanvasRepository(ref.watch(studioProvider)),
 );
 
-final privacyRepositoryProvider = Provider<PrivacyRepository>((ref) => ref.watch(studioProvider));
+final privacyRepositoryProvider = Provider<PrivacyRepository>(
+  (ref) => ref.watch(studioProvider),
+);
 
 final echoPromptProvider = Provider<String>((ref) => kPenumbraEchoSystemPrompt);
 
@@ -56,7 +62,8 @@ class AuthController extends StateNotifier<AsyncValue<AuthUser?>> {
   Future<AuthFailure?> signUpPassword(String email, String password) =>
       _unwrap(_auth.signUpWithPassword(email: email, password: password));
 
-  Future<AuthFailure?> magicLink(String email) async => (await _auth.sendMagicLink(email: email)).errOrNull;
+  Future<AuthFailure?> magicLink(String email) async =>
+      (await _auth.sendMagicLink(email: email)).errOrNull;
 
   Future<AuthFailure?> google() => _unwrap(_auth.signInWithGoogle());
   Future<AuthFailure?> github() => _unwrap(_auth.signInWithGitHub());
@@ -65,14 +72,17 @@ class AuthController extends StateNotifier<AsyncValue<AuthUser?>> {
 
   Future<void> signOut() => _auth.signOut();
 
-  Future<AuthFailure?> _unwrap(Future<Result<AuthUser, AuthFailure>> future) async {
+  Future<AuthFailure?> _unwrap(
+    Future<Result<AuthUser, AuthFailure>> future,
+  ) async {
     return (await future).errOrNull;
   }
 }
 
-final authControllerProvider = StateNotifierProvider<AuthController, AsyncValue<AuthUser?>>((ref) {
-  return AuthController(ref.watch(authRepositoryProvider));
-});
+final authControllerProvider =
+    StateNotifierProvider<AuthController, AsyncValue<AuthUser?>>((ref) {
+      return AuthController(ref.watch(authRepositoryProvider));
+    });
 
 class AppearanceController extends StateNotifier<PenumbraAppearance> {
   AppearanceController({
@@ -93,6 +103,7 @@ class AppearanceController extends StateNotifier<PenumbraAppearance> {
   }
 }
 
-final appearanceProvider = StateNotifierProvider<AppearanceController, PenumbraAppearance>(
-  (ref) => AppearanceController(),
-);
+final appearanceProvider =
+    StateNotifierProvider<AppearanceController, PenumbraAppearance>(
+      (ref) => AppearanceController(),
+    );

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -31,15 +31,27 @@ final routerProvider = Provider<GoRouter>((ref) {
     routes: [
       GoRoute(
         path: '/',
-        pageBuilder: (context, state) => penumbraRoutePage(key: state.pageKey, child: const LandingPage(), context: context),
+        pageBuilder: (context, state) => penumbraRoutePage(
+          key: state.pageKey,
+          child: const LandingPage(),
+          context: context,
+        ),
       ),
       GoRoute(
         path: '/sign-in',
-        pageBuilder: (context, state) => penumbraRoutePage(key: state.pageKey, child: const SignInPage(), context: context),
+        pageBuilder: (context, state) => penumbraRoutePage(
+          key: state.pageKey,
+          child: const SignInPage(),
+          context: context,
+        ),
       ),
       GoRoute(
         path: '/boards',
-        pageBuilder: (context, state) => penumbraRoutePage(key: state.pageKey, child: const BoardsPage(), context: context),
+        pageBuilder: (context, state) => penumbraRoutePage(
+          key: state.pageKey,
+          child: const BoardsPage(),
+          context: context,
+        ),
       ),
       GoRoute(
         path: '/boards/:id',
@@ -51,12 +63,19 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: '/privacy',
-        pageBuilder: (context, state) => penumbraRoutePage(key: state.pageKey, child: const PrivacyPage(), context: context),
+        pageBuilder: (context, state) => penumbraRoutePage(
+          key: state.pageKey,
+          child: const PrivacyPage(),
+          context: context,
+        ),
       ),
       GoRoute(
         path: '/making-of',
-        pageBuilder: (context, state) =>
-            penumbraRoutePage(key: state.pageKey, child: const MakingOfPage(), context: context),
+        pageBuilder: (context, state) => penumbraRoutePage(
+          key: state.pageKey,
+          child: const MakingOfPage(),
+          context: context,
+        ),
       ),
       GoRoute(
         path: '/legal/:slug',

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -27,7 +27,7 @@ PenumbraAppearance appearanceFromName(String? name) {
 abstract final class PenumbraInk {
   static const paper = Color(0xFFF4EFE6);
   static const ink = Color(0xFF1C1712);
-  static const mute = Color(0xFF6F675C);
+  static const mute = Color(0xFF534C44);
   static const copper = Color(0xFFC45C26);
   static const darkPaper = Color(0xFF16130F);
   static const cream = Color(0xFFF4EFE6);
@@ -36,70 +36,73 @@ abstract final class PenumbraInk {
 
 abstract final class PenumbraThemes {
   static FThemeData light() => _paper(
-        debugLabel: 'Penumbra Light',
-        colors: FColors.zincLight.copyWith(
-          background: PenumbraInk.paper,
-          foreground: PenumbraInk.ink,
-          primary: PenumbraInk.copper,
-          primaryForeground: PenumbraInk.paper,
-          secondary: const Color(0xFFEBE4D8),
-          secondaryForeground: PenumbraInk.ink,
-          muted: const Color(0xFFEBE4D8),
-          mutedForeground: PenumbraInk.mute,
-          card: const Color(0xFFF8F4EC),
-          border: const Color(0xFFDDD4C6),
-        ),
-      );
+    debugLabel: 'Penumbra Light',
+    colors: FColors.zincLight.copyWith(
+      background: PenumbraInk.paper,
+      foreground: PenumbraInk.ink,
+      primary: PenumbraInk.copper,
+      primaryForeground: PenumbraInk.paper,
+      secondary: const Color(0xFFEBE4D8),
+      secondaryForeground: PenumbraInk.ink,
+      muted: const Color(0xFFEBE4D8),
+      mutedForeground: PenumbraInk.mute,
+      card: const Color(0xFFF8F4EC),
+      border: const Color(0xFFDDD4C6),
+    ),
+  );
 
   static FThemeData dark() => _paper(
-        debugLabel: 'Penumbra Dark',
-        colors: FColors.zincDark.copyWith(
-          background: PenumbraInk.darkPaper,
-          foreground: PenumbraInk.cream,
-          primary: PenumbraInk.copper,
-          primaryForeground: PenumbraInk.cream,
-          secondary: const Color(0xFF1F1A15),
-          secondaryForeground: PenumbraInk.cream,
-          muted: const Color(0xFF1F1A15),
-          mutedForeground: const Color(0xFFB7AFA4),
-          card: const Color(0xFF1C1712),
-          border: const Color(0xFF2F2922),
-        ),
-      );
+    debugLabel: 'Penumbra Dark',
+    colors: FColors.zincDark.copyWith(
+      background: PenumbraInk.darkPaper,
+      foreground: PenumbraInk.cream,
+      primary: PenumbraInk.copper,
+      primaryForeground: PenumbraInk.cream,
+      secondary: const Color(0xFF1F1A15),
+      secondaryForeground: PenumbraInk.cream,
+      muted: const Color(0xFF1F1A15),
+      mutedForeground: const Color(0xFFB7AFA4),
+      card: const Color(0xFF1C1712),
+      border: const Color(0xFF2F2922),
+    ),
+  );
 
   static FThemeData highContrastLight() => _paper(
-        debugLabel: 'High contrast light',
-        colors: FColors.neutralLight.copyWith(
-          background: const Color(0xFFFFFFFF),
-          foreground: const Color(0xFF000000),
-          primary: const Color(0xFF000000),
-          primaryForeground: const Color(0xFFFFFFFF),
-          secondary: const Color(0xFFFFFFFF),
-          secondaryForeground: const Color(0xFF000000),
-          muted: const Color(0xFFFFFFFF),
-          mutedForeground: const Color(0xFF000000),
-          card: const Color(0xFFFFFFFF),
-          border: const Color(0xFF000000),
-        ),
-      );
+    debugLabel: 'High contrast light',
+    colors: FColors.neutralLight.copyWith(
+      background: const Color(0xFFFFFFFF),
+      foreground: const Color(0xFF000000),
+      primary: const Color(0xFF000000),
+      primaryForeground: const Color(0xFFFFFFFF),
+      secondary: const Color(0xFFFFFFFF),
+      secondaryForeground: const Color(0xFF000000),
+      muted: const Color(0xFFFFFFFF),
+      mutedForeground: const Color(0xFF000000),
+      card: const Color(0xFFFFFFFF),
+      border: const Color(0xFF000000),
+    ),
+  );
 
   static FThemeData highContrastDark() => _paper(
-        debugLabel: 'High contrast dark',
-        colors: FColors.neutralDark.copyWith(
-          background: const Color(0xFF000000),
-          foreground: const Color(0xFFFFFFFF),
-          primary: const Color(0xFFFFFFFF),
-          primaryForeground: const Color(0xFF000000),
-          secondary: const Color(0xFF000000),
-          secondaryForeground: const Color(0xFFFFFFFF),
-          muted: const Color(0xFF000000),
-          mutedForeground: const Color(0xFFFFFFFF),
-          card: const Color(0xFF000000),
-          border: const Color(0xFFFFFFFF),
-        ),
-      );
+    debugLabel: 'High contrast dark',
+    colors: FColors.neutralDark.copyWith(
+      background: const Color(0xFF000000),
+      foreground: const Color(0xFFFFFFFF),
+      primary: const Color(0xFFFFFFFF),
+      primaryForeground: const Color(0xFF000000),
+      secondary: const Color(0xFF000000),
+      secondaryForeground: const Color(0xFFFFFFFF),
+      muted: const Color(0xFF000000),
+      mutedForeground: const Color(0xFFFFFFFF),
+      card: const Color(0xFF000000),
+      border: const Color(0xFFFFFFFF),
+    ),
+  );
 
-  static FThemeData _paper({required String debugLabel, required FColors colors}) {
+  static FThemeData _paper({
+    required String debugLabel,
+    required FColors colors,
+  }) {
     final typography = FTypography.inherit(colors: colors, touch: false);
     return FThemeData(
       touch: false,
@@ -125,12 +128,19 @@ abstract final class PenumbraThemes {
     );
   }
 
-  static (FThemeData light, FThemeData dark) pair(PenumbraAppearance appearance, Brightness platform) {
+  static (FThemeData light, FThemeData dark) pair(
+    PenumbraAppearance appearance,
+    Brightness platform,
+  ) {
     return switch (appearance) {
       PenumbraAppearance.light => (light(), light()),
       PenumbraAppearance.dark => (dark(), dark()),
-      PenumbraAppearance.highContrast => (highContrastLight(), highContrastDark()),
-      PenumbraAppearance.system => platform == Brightness.dark ? (dark(), dark()) : (light(), light()),
+      PenumbraAppearance.highContrast => (
+        highContrastLight(),
+        highContrastDark(),
+      ),
+      PenumbraAppearance.system =>
+        platform == Brightness.dark ? (dark(), dark()) : (light(), light()),
     };
   }
 }

--- a/lib/core/a11y/motion.dart
+++ b/lib/core/a11y/motion.dart
@@ -1,20 +1,27 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 
-bool penumbraReduceMotion(BuildContext context) => MediaQuery.disableAnimationsOf(context);
+bool penumbraReduceMotion(BuildContext context) =>
+    MediaQuery.disableAnimationsOf(context);
 
 Duration penumbraDuration(BuildContext context, Duration duration) =>
     penumbraReduceMotion(context) ? Duration.zero : duration;
 
 Duration penumbraRouteDuration(BuildContext context) =>
-    penumbraReduceMotion(context) ? const Duration(milliseconds: 80) : const Duration(milliseconds: 280);
+    penumbraReduceMotion(context)
+    ? const Duration(milliseconds: 80)
+    : const Duration(milliseconds: 280);
 
 extension PenumbraMotion on Widget {
   Widget penumbraEnter(BuildContext context, {int delayMs = 0, int index = 0}) {
     if (penumbraReduceMotion(context)) return this;
     return animate(delay: Duration(milliseconds: delayMs + index * 55))
         .fadeIn(duration: 420.ms, curve: Curves.easeOutCubic)
-        .move(begin: const Offset(0, 12), duration: 420.ms, curve: Curves.easeOutCubic);
+        .move(
+          begin: const Offset(0, 12),
+          duration: 420.ms,
+          curve: Curves.easeOutCubic,
+        );
   }
 
   Widget penumbraCardAppear(BuildContext context) {

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -39,16 +39,23 @@ class PenumbraConfig {
   final String productionOrigin;
   final String geminiApiKey;
 
-  bool get hasRemoteBackend => supabaseUrl.isNotEmpty && supabaseAnonKey.isNotEmpty;
+  bool get hasRemoteBackend =>
+      supabaseUrl.isNotEmpty && supabaseAnonKey.isNotEmpty;
   bool get hasGemini => geminiApiKey.trim().isNotEmpty;
 
-  StudioMode get studioMode => resolveStudioMode(supabaseUrl: supabaseUrl, supabaseAnonKey: supabaseAnonKey);
+  StudioMode get studioMode => resolveStudioMode(
+    supabaseUrl: supabaseUrl,
+    supabaseAnonKey: supabaseAnonKey,
+  );
 }
 
 enum StudioMode { memory, supabase }
 
 /// Both dart-defines, or neither. A half-set config fails closed.
-StudioMode resolveStudioMode({required String supabaseUrl, required String supabaseAnonKey}) {
+StudioMode resolveStudioMode({
+  required String supabaseUrl,
+  required String supabaseAnonKey,
+}) {
   final url = supabaseUrl.trim();
   final key = supabaseAnonKey.trim();
   if (url.isEmpty && key.isEmpty) return StudioMode.memory;

--- a/lib/core/crypto/key_derivation.dart
+++ b/lib/core/crypto/key_derivation.dart
@@ -36,7 +36,10 @@ class KeyDerivation {
       return const Err(CryptoFailure('Salt is too short.'));
     }
     try {
-      final key = await _kdf.deriveKeyFromPassword(password: secret, nonce: salt);
+      final key = await _kdf.deriveKeyFromPassword(
+        password: secret,
+        nonce: salt,
+      );
       final bytes = await key.extractBytes();
       return Ok(Uint8List.fromList(bytes));
     } on Object {

--- a/lib/core/crypto/payload_cipher.dart
+++ b/lib/core/crypto/payload_cipher.dart
@@ -49,7 +49,8 @@ final class Ciphertext {
 
 /// Encrypts board node payloads. The DEK never leaves the client.
 class PayloadCipher {
-  PayloadCipher({AesGcm? algorithm}) : _algorithm = algorithm ?? AesGcm.with256bits();
+  PayloadCipher({AesGcm? algorithm})
+    : _algorithm = algorithm ?? AesGcm.with256bits();
 
   final AesGcm _algorithm;
 
@@ -93,7 +94,10 @@ class PayloadCipher {
         nonce: ciphertext.nonce,
         mac: Mac(ciphertext.mac),
       );
-      final clear = await _algorithm.decrypt(box, secretKey: SecretKey(dekBytes));
+      final clear = await _algorithm.decrypt(
+        box,
+        secretKey: SecretKey(dekBytes),
+      );
       return Ok(Uint8List.fromList(clear));
     } on SecretBoxAuthenticationError {
       return const Err(CryptoFailure('Authentication tag mismatch.'));

--- a/lib/core/crypto/recovery_phrase.dart
+++ b/lib/core/crypto/recovery_phrase.dart
@@ -39,7 +39,9 @@ class RecoveryPhrase {
     if (wordlist.length != 2048) {
       return const Err(CryptoFailure('Wordlist must contain 2048 words.'));
     }
-    final lookup = <String, int>{for (var i = 0; i < wordlist.length; i++) wordlist[i]: i};
+    final lookup = <String, int>{
+      for (var i = 0; i < wordlist.length; i++) wordlist[i]: i,
+    };
     final indices = <int>[];
     for (final word in words) {
       final index = lookup[word];
@@ -49,7 +51,10 @@ class RecoveryPhrase {
       indices.add(index);
     }
     final entropy = _indicesToEntropy(indices);
-    final checksumOk = switch (fromEntropy(entropy: entropy, wordlist: wordlist)) {
+    final checksumOk = switch (fromEntropy(
+      entropy: entropy,
+      wordlist: wordlist,
+    )) {
       Ok(:final value) => value.display == words.join(' '),
       Err() => false,
     };
@@ -62,7 +67,9 @@ class RecoveryPhrase {
   Result<Uint8List, CryptoFailure> toEntropy(List<String> wordlist) {
     return parse(phrase: display, wordlist: wordlist).when(
       ok: (phrase) {
-        final lookup = <String, int>{for (var i = 0; i < wordlist.length; i++) wordlist[i]: i};
+        final lookup = <String, int>{
+          for (var i = 0; i < wordlist.length; i++) wordlist[i]: i,
+        };
         final indices = [for (final word in phrase.words) lookup[word]!];
         return Ok(_indicesToEntropy(indices));
       },

--- a/lib/core/crypto/wordlist.dart
+++ b/lib/core/crypto/wordlist.dart
@@ -15,7 +15,9 @@ class Bip39Wordlist {
         .where((w) => w.isNotEmpty)
         .toList(growable: false);
     if (words.length != 2048) {
-      throw StateError('BIP39 wordlist must contain 2048 words, found ${words.length}.');
+      throw StateError(
+        'BIP39 wordlist must contain 2048 words, found ${words.length}.',
+      );
     }
     return Bip39Wordlist(words);
   }

--- a/lib/core/errors.dart
+++ b/lib/core/errors.dart
@@ -18,7 +18,8 @@ final class ForbiddenFailure extends AppFailure {
 }
 
 final class UnauthenticatedFailure extends AppFailure {
-  const UnauthenticatedFailure([String message = 'Sign in required.']) : super('unauthenticated', message);
+  const UnauthenticatedFailure([String message = 'Sign in required.'])
+    : super('unauthenticated', message);
 }
 
 final class CryptoFailure extends AppFailure {

--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -2,7 +2,10 @@
 sealed class Result<S, F> {
   const Result();
 
-  T when<T>({required T Function(S value) ok, required T Function(F failure) err}) {
+  T when<T>({
+    required T Function(S value) ok,
+    required T Function(F failure) err,
+  }) {
     return switch (this) {
       Ok(:final value) => ok(value),
       Err(:final failure) => err(failure),

--- a/lib/features/auth/data/passkey_ceremony_factory.dart
+++ b/lib/features/auth/data/passkey_ceremony_factory.dart
@@ -1,0 +1,6 @@
+import 'passkey_ceremony_stub.dart'
+    if (dart.library.js_interop) 'passkey_ceremony_web.dart';
+
+import '../domain/passkey_ceremony.dart';
+
+PasskeyCeremony createPasskeyCeremony() => platformPasskeyCeremony();

--- a/lib/features/auth/data/passkey_ceremony_stub.dart
+++ b/lib/features/auth/data/passkey_ceremony_stub.dart
@@ -1,0 +1,3 @@
+import '../domain/passkey_ceremony.dart';
+
+PasskeyCeremony platformPasskeyCeremony() => const UnsupportedPasskeyCeremony();

--- a/lib/features/auth/data/passkey_ceremony_web.dart
+++ b/lib/features/auth/data/passkey_ceremony_web.dart
@@ -1,0 +1,70 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:web/web.dart' as web;
+
+import '../domain/passkey_ceremony.dart';
+
+PasskeyCeremony platformPasskeyCeremony() => const WebPasskeyCeremony();
+
+class WebPasskeyCeremony implements PasskeyCeremony {
+  const WebPasskeyCeremony();
+
+  @override
+  bool get isSupported {
+    final host = web.window.location.hostname;
+    final protocol = web.window.location.protocol;
+    final secure =
+        protocol == 'https:' || host == 'localhost' || host == '127.0.0.1';
+    if (!secure) return false;
+    return web.window.has('PublicKeyCredential');
+  }
+
+  @override
+  Future<Map<String, dynamic>> create(Map<String, dynamic> publicKeyOptions) {
+    return _run('create', publicKeyOptions);
+  }
+
+  @override
+  Future<Map<String, dynamic>> get(Map<String, dynamic> publicKeyOptions) {
+    return _run('get', publicKeyOptions);
+  }
+
+  Future<Map<String, dynamic>> _run(
+    String method,
+    Map<String, dynamic> publicKeyOptions,
+  ) async {
+    if (!isSupported) {
+      throw UnsupportedError(kPasskeyUnavailableMessage);
+    }
+    final credentials = web.window.navigator.credentials as JSObject;
+    final args = <String, Object?>{'publicKey': publicKeyOptions}.jsify();
+    try {
+      final promise = credentials.callMethod(method.toJS, args) as JSPromise;
+      final credential = await promise.toDart;
+      if (credential == null) throw const PasskeyCancelled();
+      return _toJson(credential as JSObject);
+    } catch (error) {
+      if (error is PasskeyCancelled) rethrow;
+      final text = error.toString().toLowerCase();
+      if (text.contains('notallowed') || text.contains('abort')) {
+        throw const PasskeyCancelled();
+      }
+      if (text.contains('notsupported') || text.contains('security')) {
+        throw UnsupportedError(kPasskeyUnavailableMessage);
+      }
+      rethrow;
+    }
+  }
+
+  Map<String, dynamic> _toJson(JSObject credential) {
+    if (credential.has('toJSON')) {
+      final raw = credential.callMethod('toJSON'.toJS);
+      final dartified = (raw as JSAny).dartify();
+      if (dartified is Map) {
+        return Map<String, dynamic>.from(dartified);
+      }
+    }
+    throw UnsupportedError(kPasskeyUnavailableMessage);
+  }
+}

--- a/lib/features/auth/domain/auth_models.dart
+++ b/lib/features/auth/domain/auth_models.dart
@@ -29,7 +29,8 @@ class AuthUser {
       email: email ?? this.email,
       displayName: displayName ?? this.displayName,
       methods: methods ?? this.methods,
-      needsRecoveryPhraseReveal: needsRecoveryPhraseReveal ?? this.needsRecoveryPhraseReveal,
+      needsRecoveryPhraseReveal:
+          needsRecoveryPhraseReveal ?? this.needsRecoveryPhraseReveal,
     );
   }
 }
@@ -40,11 +41,15 @@ sealed class AuthFailure {
 }
 
 final class InvalidCredentialsFailure extends AuthFailure {
-  const InvalidCredentialsFailure([super.message = 'Those credentials were not accepted.']);
+  const InvalidCredentialsFailure([
+    super.message = 'Those credentials were not accepted.',
+  ]);
 }
 
 final class RateLimitedFailure extends AuthFailure {
-  const RateLimitedFailure([super.message = 'Too many attempts. Wait a moment.']);
+  const RateLimitedFailure([
+    super.message = 'Too many attempts. Wait a moment.',
+  ]);
 }
 
 final class AuthCancelledFailure extends AuthFailure {
@@ -52,7 +57,9 @@ final class AuthCancelledFailure extends AuthFailure {
 }
 
 final class AuthUnavailableFailure extends AuthFailure {
-  const AuthUnavailableFailure([super.message = 'This sign-in method is not available here.']);
+  const AuthUnavailableFailure([
+    super.message = 'This sign-in method is not available here.',
+  ]);
 }
 
 final class WeakSecretFailure extends AuthFailure {

--- a/lib/features/auth/domain/passkey_ceremony.dart
+++ b/lib/features/auth/domain/passkey_ceremony.dart
@@ -1,0 +1,48 @@
+import 'auth_models.dart';
+
+const kPasskeyUnavailableMessage =
+    'This browser cannot create a passkey. Use Google, GitHub, a magic link, or a password.';
+
+const kPasskeyProjectDisabledMessage =
+    'Passkeys are not enabled on this Supabase project yet. Use Google, GitHub, a magic link, or a password.';
+
+/// Platform WebAuthn ceremony. Binary-free JSON maps in W3C Level 3 form.
+abstract class PasskeyCeremony {
+  bool get isSupported;
+
+  Future<Map<String, dynamic>> create(Map<String, dynamic> publicKeyOptions);
+
+  Future<Map<String, dynamic>> get(Map<String, dynamic> publicKeyOptions);
+}
+
+class PasskeyCancelled implements Exception {
+  const PasskeyCancelled();
+}
+
+class UnsupportedPasskeyCeremony implements PasskeyCeremony {
+  const UnsupportedPasskeyCeremony();
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<Map<String, dynamic>> create(Map<String, dynamic> publicKeyOptions) {
+    throw const PasskeyCancelled();
+  }
+
+  @override
+  Future<Map<String, dynamic>> get(Map<String, dynamic> publicKeyOptions) {
+    throw const PasskeyCancelled();
+  }
+}
+
+AuthFailure passkeyUnavailable({
+  required bool supported,
+  bool projectDisabled = false,
+}) {
+  if (projectDisabled)
+    return const AuthUnavailableFailure(kPasskeyProjectDisabledMessage);
+  if (!supported)
+    return const AuthUnavailableFailure(kPasskeyUnavailableMessage);
+  return const AuthUnavailableFailure(kPasskeyUnavailableMessage);
+}

--- a/lib/features/auth/presentation/sign_in_page.dart
+++ b/lib/features/auth/presentation/sign_in_page.dart
@@ -33,7 +33,11 @@ class _SignInPageState extends ConsumerState<SignInPage> {
 
   bool get _busy => _busyId != null;
 
-  Future<void> _run(String id, Future<AuthFailure?> Function() action, {String? success}) async {
+  Future<void> _run(
+    String id,
+    Future<AuthFailure?> Function() action, {
+    String? success,
+  }) async {
     setState(() {
       _busyId = id;
       _error = null;
@@ -76,7 +80,11 @@ class _SignInPageState extends ConsumerState<SignInPage> {
               borderRadius: BorderRadius.circular(20),
               border: Border.all(color: theme.colors.border),
               boxShadow: [
-                BoxShadow(color: theme.colors.foreground.withValues(alpha: 0.05), blurRadius: 28, offset: const Offset(0, 12)),
+                BoxShadow(
+                  color: theme.colors.foreground.withValues(alpha: 0.05),
+                  blurRadius: 28,
+                  offset: const Offset(0, 12),
+                ),
               ],
             ),
             child: Padding(
@@ -87,16 +95,24 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                   children: [
                     Text(
                       'Enter the half-light.',
-                      style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500),
+                      style: theme.typography.xl3.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
                     ).penumbraEnter(context),
                     const SizedBox(height: 8),
                     Text(
                       'Passkeys are preferred. Passwords are the weakest path and must be at least 12 characters.',
-                      style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground, height: 1.45),
+                      style: theme.typography.sm.copyWith(
+                        color: theme.colors.mutedForeground,
+                        height: 1.45,
+                      ),
                     ).penumbraEnter(context, delayMs: 40),
                     const SizedBox(height: 28),
                     if (_error != null) ...[
-                      FAlert(variant: FAlertVariant.destructive, title: Text(_error!)).penumbraEnter(context),
+                      FAlert(
+                        variant: FAlertVariant.destructive,
+                        title: Text(_error!),
+                      ).penumbraEnter(context),
                       const SizedBox(height: 16),
                     ],
                     if (_info != null) ...[
@@ -104,21 +120,45 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       const SizedBox(height: 16),
                     ],
                     FButton(
-                      onPress: _busy ? null : () => _run('passkey', () => ref.read(authControllerProvider.notifier).passkey()),
-                      prefix: _prefix('passkey', const Icon(FLucideIcons.fingerprint)),
+                      onPress: _busy
+                          ? null
+                          : () => _run(
+                              'passkey',
+                              () => ref
+                                  .read(authControllerProvider.notifier)
+                                  .passkey(),
+                            ),
+                      prefix: _prefix(
+                        'passkey',
+                        const Icon(FLucideIcons.fingerprint),
+                      ),
                       child: const Text('Continue with a passkey'),
                     ).penumbraEnter(context, delayMs: 80),
                     const SizedBox(height: 10),
                     FButton(
                       variant: FButtonVariant.outline,
-                      onPress: _busy ? null : () => _run('google', () => ref.read(authControllerProvider.notifier).google()),
+                      onPress: _busy
+                          ? null
+                          : () => _run(
+                              'google',
+                              () => ref
+                                  .read(authControllerProvider.notifier)
+                                  .google(),
+                            ),
                       prefix: _prefix('google', const Icon(FLucideIcons.globe)),
                       child: const Text('Continue with Google'),
                     ).penumbraEnter(context, delayMs: 110),
                     const SizedBox(height: 10),
                     FButton(
                       variant: FButtonVariant.outline,
-                      onPress: _busy ? null : () => _run('github', () => ref.read(authControllerProvider.notifier).github()),
+                      onPress: _busy
+                          ? null
+                          : () => _run(
+                              'github',
+                              () => ref
+                                  .read(authControllerProvider.notifier)
+                                  .github(),
+                            ),
                       prefix: _prefix('github', const Icon(FLucideIcons.code)),
                       child: const Text('Continue with GitHub'),
                     ).penumbraEnter(context, delayMs: 140),
@@ -128,7 +168,12 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                         const Expanded(child: FDivider()),
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: Text('or', style: theme.typography.xs.copyWith(color: theme.colors.mutedForeground)),
+                          child: Text(
+                            'or',
+                            style: theme.typography.xs.copyWith(
+                              color: theme.colors.mutedForeground,
+                            ),
+                          ),
                         ),
                         const Expanded(child: FDivider()),
                       ],
@@ -136,7 +181,9 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                     const SizedBox(height: 24),
                     FTextField.email(
                       control: FTextFieldControl.managed(controller: _email),
-                      description: const Text('Used only to restore your studio.'),
+                      description: const Text(
+                        'Used only to restore your studio.',
+                      ),
                     ).penumbraEnter(context, delayMs: 180),
                     const SizedBox(height: 12),
                     FButton(
@@ -145,20 +192,25 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                           ? null
                           : () async {
                               setState(() => _busyId = 'magic');
-                              final failure = await ref.read(authControllerProvider.notifier).magicLink(_email.text);
+                              final failure = await ref
+                                  .read(authControllerProvider.notifier)
+                                  .magicLink(_email.text);
                               if (!mounted) return;
-                              final signedIn = ref.read(authControllerProvider).value != null;
+                              final signedIn =
+                                  ref.read(authControllerProvider).value !=
+                                  null;
                               setState(() {
                                 _busyId = null;
                                 _error = failure?.message;
                                 _info = failure == null
                                     ? (signedIn
-                                        ? 'Magic link sent (in this demo the session is opened immediately).'
-                                        : 'Check your email for a link. Keep this tab open.')
+                                          ? 'Magic link sent (in this demo the session is opened immediately).'
+                                          : 'Check your email for a link. Keep this tab open.')
                                     : null;
                               });
                               if (!context.mounted) return;
-                              if (failure == null && signedIn) context.go('/boards');
+                              if (failure == null && signedIn)
+                                context.go('/boards');
                             },
                       prefix: _prefix('magic', const Icon(FLucideIcons.mail)),
                       child: const Text('Email me a magic link'),
@@ -166,15 +218,22 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                     const SizedBox(height: 8),
                     FButton(
                       variant: FButtonVariant.ghost,
-                      onPress: () => setState(() => _passwordOpen = !_passwordOpen),
-                      child: Text(_passwordOpen ? 'Hide password' : 'Use a password instead'),
+                      onPress: () =>
+                          setState(() => _passwordOpen = !_passwordOpen),
+                      child: Text(
+                        _passwordOpen
+                            ? 'Hide password'
+                            : 'Use a password instead',
+                      ),
                     ).penumbraEnter(context, delayMs: 220),
                     if (_passwordOpen) ...[
                       const SizedBox(height: 12),
                       FTextField(
                         label: const Text('Password'),
                         obscureText: true,
-                        control: FTextFieldControl.managed(controller: _password),
+                        control: FTextFieldControl.managed(
+                          controller: _password,
+                        ),
                       ),
                       const SizedBox(height: 16),
                       FButton(
@@ -183,7 +242,12 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                             ? null
                             : () => _run(
                                 'password',
-                                () => ref.read(authControllerProvider.notifier).signInPassword(_email.text, _password.text),
+                                () => ref
+                                    .read(authControllerProvider.notifier)
+                                    .signInPassword(
+                                      _email.text,
+                                      _password.text,
+                                    ),
                               ),
                         prefix: _prefix('password', const SizedBox.shrink()),
                         child: const Text('Sign in with password'),
@@ -195,7 +259,12 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                             ? null
                             : () => _run(
                                 'signup',
-                                () => ref.read(authControllerProvider.notifier).signUpPassword(_email.text, _password.text),
+                                () => ref
+                                    .read(authControllerProvider.notifier)
+                                    .signUpPassword(
+                                      _email.text,
+                                      _password.text,
+                                    ),
                               ),
                         child: const Text('Create an account'),
                       ),

--- a/lib/features/boards/domain/board.dart
+++ b/lib/features/boards/domain/board.dart
@@ -15,11 +15,7 @@ class Board {
   final DateTime updatedAt;
   final bool restricted;
 
-  Board copyWith({
-    String? title,
-    DateTime? updatedAt,
-    bool? restricted,
-  }) {
+  Board copyWith({String? title, DateTime? updatedAt, bool? restricted}) {
     return Board(
       id: id,
       ownerId: ownerId,
@@ -68,12 +64,18 @@ class BoardNode {
 
   String get semanticsLabel {
     final body = switch (kind) {
-      NodeKind.text => text?.trim().isNotEmpty == true ? text!.trim() : 'Untitled note',
+      NodeKind.text =>
+        text?.trim().isNotEmpty == true ? text!.trim() : 'Untitled note',
       NodeKind.swatch => 'Colour swatch',
-      NodeKind.echo => text?.trim().isNotEmpty == true ? 'Echo of ${text!.trim()}' : 'Echo of an unnamed thought',
+      NodeKind.echo =>
+        text?.trim().isNotEmpty == true
+            ? 'Echo of ${text!.trim()}'
+            : 'Echo of an unnamed thought',
     };
     return body;
   }
+
+  BoardNode movedBy(double dx, double dy) => copyWith(x: x + dx, y: y + dy);
 
   BoardNode copyWith({
     double? x,

--- a/lib/features/boards/domain/board_repository.dart
+++ b/lib/features/boards/domain/board_repository.dart
@@ -6,7 +6,13 @@ abstract class BoardRepository {
   Future<Result<List<Board>, AppFailure>> listMine();
   Future<Result<Board, AppFailure>> getById(String id);
   Future<Result<Board, AppFailure>> create({required String title});
-  Future<Result<Board, AppFailure>> rename({required String id, required String title});
+  Future<Result<Board, AppFailure>> rename({
+    required String id,
+    required String title,
+  });
   Future<Result<void, AppFailure>> delete(String id);
-  Future<Result<Board, AppFailure>> setRestricted({required String id, required bool restricted});
+  Future<Result<Board, AppFailure>> setRestricted({
+    required String id,
+    required bool restricted,
+  });
 }

--- a/lib/features/boards/domain/echo_pairing.dart
+++ b/lib/features/boards/domain/echo_pairing.dart
@@ -20,7 +20,10 @@ abstract final class EchoPairing {
     return echo.copyWith(x: parent.x + offsetX, y: parent.y + offsetY);
   }
 
-  static Result<void, AppFailure> validateWrite(BoardNode node, List<BoardNode> siblings) {
+  static Result<void, AppFailure> validateWrite(
+    BoardNode node,
+    List<BoardNode> siblings,
+  ) {
     if (node.kind != NodeKind.echo) {
       if (node.parentId != null) {
         return const Err(ValidationFailure('Only an echo names a parent.'));
@@ -45,8 +48,14 @@ abstract final class EchoPairing {
       return const Err(ValidationFailure('Echoes answer human slips only.'));
     }
     for (final sibling in siblings) {
-      if (sibling.id != node.id && sibling.kind == NodeKind.echo && sibling.parentId == parentId) {
-        return const Err(ValidationFailure('This slip already has an echo. Dismiss it to summon again.'));
+      if (sibling.id != node.id &&
+          sibling.kind == NodeKind.echo &&
+          sibling.parentId == parentId) {
+        return const Err(
+          ValidationFailure(
+            'This slip already has an echo. Dismiss it to summon again.',
+          ),
+        );
       }
     }
     return const Ok(null);
@@ -91,7 +100,10 @@ abstract final class EchoPairing {
   }
 
   static String numeral(List<BoardNode> conversation, BoardNode node) {
-    final humans = [for (final item in conversation) if (item.kind != NodeKind.echo) item];
+    final humans = [
+      for (final item in conversation)
+        if (item.kind != NodeKind.echo) item,
+    ];
     if (node.kind == NodeKind.echo) {
       final parentIndex = humans.indexWhere((item) => item.id == node.parentId);
       final n = parentIndex < 0 ? humans.length + 1 : parentIndex + 1;

--- a/lib/features/boards/domain/node_motion.dart
+++ b/lib/features/boards/domain/node_motion.dart
@@ -1,0 +1,35 @@
+import 'board.dart';
+import 'echo_pairing.dart';
+
+/// Pointer and keyboard moves share this rule: a human slip takes its echo with it.
+abstract final class NodeMotion {
+  static List<BoardNode> moved(
+    List<BoardNode> nodes, {
+    required String id,
+    required double dx,
+    required double dy,
+  }) {
+    BoardNode? target;
+    for (final node in nodes) {
+      if (node.id == id) {
+        target = node;
+        break;
+      }
+    }
+    if (target == null || (dx == 0 && dy == 0)) return nodes;
+
+    var next = [
+      for (final node in nodes) node.id == id ? node.movedBy(dx, dy) : node,
+    ];
+    if (target.kind == NodeKind.text) {
+      final echo = EchoPairing.echoFor(nodes, id);
+      if (echo != null) {
+        next = [
+          for (final node in next)
+            node.id == echo.id ? node.movedBy(dx, dy) : node,
+        ];
+      }
+    }
+    return next;
+  }
+}

--- a/lib/features/boards/presentation/boards_page.dart
+++ b/lib/features/boards/presentation/boards_page.dart
@@ -24,7 +24,12 @@ class BoardsPage extends ConsumerWidget {
           }
           final result = snapshot.data!;
           return result.when(
-            err: (failure) => PenumbraPage(child: FAlert(variant: FAlertVariant.destructive, title: Text(failure.message))),
+            err: (failure) => PenumbraPage(
+              child: FAlert(
+                variant: FAlertVariant.destructive,
+                title: Text(failure.message),
+              ),
+            ),
             ok: (boards) => _BoardsBody(boards: boards),
           );
         },
@@ -52,13 +57,121 @@ class _BoardsBodyState extends ConsumerState<_BoardsBody> {
   }
 
   Future<void> _create() async {
-    final result = await ref.read(boardRepositoryProvider).create(title: _title.text);
+    final result = await ref
+        .read(boardRepositoryProvider)
+        .create(title: _title.text);
     if (!mounted) return;
     result.when(
       ok: (board) {
         setState(() => _boards = [board, ..._boards]);
         _title.clear();
         context.go('/boards/${board.id}');
+      },
+      err: (failure) => announce(context, failure.message),
+    );
+  }
+
+  Future<void> _rename(Board board) async {
+    final controller = TextEditingController(text: board.title);
+    final next = await showFDialog<String>(
+      context: context,
+      builder: (context, style, animation) => FDialog(
+        animation: animation,
+        title: const Text('Rename this board'),
+        body: FTextField(
+          label: const Text('Title'),
+          control: FTextFieldControl.managed(controller: controller),
+        ),
+        actions: [
+          FButton(
+            onPress: () => Navigator.of(context).pop(controller.text.trim()),
+            child: const Text('Save title'),
+          ),
+          FButton(
+            variant: FButtonVariant.outline,
+            onPress: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (!mounted || next == null || next.isEmpty || next == board.title) return;
+    final result = await ref
+        .read(boardRepositoryProvider)
+        .rename(id: board.id, title: next);
+    if (!mounted) return;
+    result.when(
+      ok: (updated) {
+        setState(
+          () => _boards = [
+            for (final item in _boards) item.id == updated.id ? updated : item,
+          ],
+        );
+        announce(context, 'Board renamed.');
+      },
+      err: (failure) => announce(context, failure.message),
+    );
+  }
+
+  Future<void> _toggleRestrict(Board board) async {
+    final result = await ref
+        .read(boardRepositoryProvider)
+        .setRestricted(id: board.id, restricted: !board.restricted);
+    if (!mounted) return;
+    result.when(
+      ok: (updated) {
+        setState(
+          () => _boards = [
+            for (final item in _boards) item.id == updated.id ? updated : item,
+          ],
+        );
+        announce(
+          context,
+          updated.restricted
+              ? 'Board restricted (Art. 18).'
+              : 'Board unrestricted.',
+        );
+      },
+      err: (failure) => announce(context, failure.message),
+    );
+  }
+
+  Future<void> _delete(Board board) async {
+    final confirmed = await showFDialog<bool>(
+      context: context,
+      builder: (context, style, animation) => FDialog(
+        animation: animation,
+        title: const Text('Delete this board'),
+        body: const Text(
+          'The board and its cards will be removed. This cannot be undone.',
+        ),
+        actions: [
+          FButton(
+            variant: FButtonVariant.destructive,
+            onPress: () => Navigator.of(context).pop(true),
+            child: const Text('Delete this board'),
+          ),
+          FButton(
+            variant: FButtonVariant.outline,
+            onPress: () => Navigator.of(context).pop(false),
+            child: const Text('Keep it'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    final result = await ref.read(boardRepositoryProvider).delete(board.id);
+    if (!mounted) return;
+    result.when(
+      ok: (_) {
+        setState(
+          () => _boards = [
+            for (final item in _boards)
+              if (item.id != board.id) item,
+          ],
+        );
+        announce(context, 'Board deleted.');
       },
       err: (failure) => announce(context, failure.message),
     );
@@ -73,11 +186,16 @@ class _BoardsBodyState extends ConsumerState<_BoardsBody> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Boards', style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500)).penumbraEnter(context),
+            Text(
+              'Boards',
+              style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500),
+            ).penumbraEnter(context),
             const SizedBox(height: 8),
             Text(
               'Each board is yours alone. Titles are metadata; the cards inside are ciphertext.',
-              style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground),
+              style: theme.typography.sm.copyWith(
+                color: theme.colors.mutedForeground,
+              ),
             ).penumbraEnter(context, delayMs: 40),
             const SizedBox(height: 24),
             Row(
@@ -108,13 +226,19 @@ class _BoardsBodyState extends ConsumerState<_BoardsBody> {
                 itemCount: _boards.length,
                 gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
                   maxCrossAxisExtent: 320,
-                  childAspectRatio: 1.28,
+                  childAspectRatio: 0.92,
                   crossAxisSpacing: 16,
                   mainAxisSpacing: 16,
                 ),
                 itemBuilder: (context, index) {
                   final board = _boards[index];
-                  return _BoardTile(board: board).penumbraEnter(context, index: index);
+                  return _BoardTile(
+                    board: board,
+                    onOpen: () => context.go('/boards/${board.id}'),
+                    onRename: () => _rename(board),
+                    onToggleRestrict: () => _toggleRestrict(board),
+                    onDelete: () => _delete(board),
+                  ).penumbraEnter(context, index: index);
                 },
               ),
           ],
@@ -125,9 +249,19 @@ class _BoardsBodyState extends ConsumerState<_BoardsBody> {
 }
 
 class _BoardTile extends StatefulWidget {
-  const _BoardTile({required this.board});
+  const _BoardTile({
+    required this.board,
+    required this.onOpen,
+    required this.onRename,
+    required this.onToggleRestrict,
+    required this.onDelete,
+  });
 
   final Board board;
+  final VoidCallback onOpen;
+  final VoidCallback onRename;
+  final VoidCallback onToggleRestrict;
+  final VoidCallback onDelete;
 
   @override
   State<_BoardTile> createState() => _BoardTileState();
@@ -147,46 +281,104 @@ class _BoardTileState extends State<_BoardTile> {
       child: Semantics(
         button: true,
         label: board.title,
-        child: GestureDetector(
-          onTap: () => context.go('/boards/${board.id}'),
-          child: AnimatedContainer(
-            duration: motion ? const Duration(milliseconds: 180) : Duration.zero,
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: theme.colors.card,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: theme.colors.border),
-              boxShadow: motion && _hover
-                  ? [
-                      BoxShadow(
-                        color: theme.colors.foreground.withValues(alpha: 0.08),
-                        blurRadius: 22,
-                        offset: const Offset(0, 10),
+        child: AnimatedContainer(
+          duration: motion ? const Duration(milliseconds: 180) : Duration.zero,
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: theme.colors.card,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: theme.colors.border),
+            boxShadow: motion && _hover
+                ? [
+                    BoxShadow(
+                      color: theme.colors.foreground.withValues(alpha: 0.08),
+                      blurRadius: 22,
+                      offset: const Offset(0, 10),
+                    ),
+                  ]
+                : const [],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                board.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.typography.lg.copyWith(
+                  fontFamily: PenumbraInk.displayFamily,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                board.restricted ? 'Restricted' : _relative(board.updatedAt),
+                style: theme.typography.xs.copyWith(
+                  color: theme.colors.mutedForeground,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  Semantics(
+                    button: true,
+                    label: 'Open ${board.title}',
+                    child: GestureDetector(
+                      onTap: widget.onOpen,
+                      child: Text(
+                        'Open',
+                        style: theme.typography.sm.copyWith(
+                          color: theme.colors.primary,
+                        ),
                       ),
-                    ]
-                  : const [],
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  board.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.typography.lg.copyWith(
-                    fontFamily: PenumbraInk.displayFamily,
-                    fontWeight: FontWeight.w500,
+                    ),
                   ),
-                ),
-                const Spacer(),
-                Text(
-                  board.restricted ? 'Restricted' : _relative(board.updatedAt),
-                  style: theme.typography.xs.copyWith(color: theme.colors.mutedForeground),
-                ),
-                const SizedBox(height: 8),
-                Text('Open', style: theme.typography.sm.copyWith(color: theme.colors.primary)),
-              ],
-            ),
+                  Semantics(
+                    button: true,
+                    label: 'Rename ${board.title}',
+                    child: GestureDetector(
+                      onTap: widget.onRename,
+                      child: Text(
+                        'Rename',
+                        style: theme.typography.sm.copyWith(
+                          color: theme.colors.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Semantics(
+                    button: true,
+                    label: board.restricted
+                        ? 'Unrestrict ${board.title}'
+                        : 'Restrict ${board.title}',
+                    child: GestureDetector(
+                      onTap: widget.onToggleRestrict,
+                      child: Text(
+                        board.restricted ? 'Unrestrict' : 'Restrict',
+                        style: theme.typography.sm.copyWith(
+                          color: theme.colors.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Semantics(
+                    button: true,
+                    label: 'Delete ${board.title}',
+                    child: GestureDetector(
+                      onTap: widget.onDelete,
+                      child: Text(
+                        'Delete',
+                        style: theme.typography.sm.copyWith(
+                          color: theme.colors.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ),
         ),
       ),
@@ -205,7 +397,10 @@ class _EmptyBoards extends StatelessWidget {
       children: [
         Text(
           'Nothing here yet. Name a board, or enter the demo studio from home.',
-          style: theme.typography.md.copyWith(color: theme.colors.mutedForeground, height: 1.45),
+          style: theme.typography.md.copyWith(
+            color: theme.colors.mutedForeground,
+            height: 1.45,
+          ),
         ),
         const SizedBox(height: 28),
         SizedBox(

--- a/lib/features/canvas/domain/echo_composer.dart
+++ b/lib/features/canvas/domain/echo_composer.dart
@@ -31,7 +31,11 @@ EchoComposer penumbraEchoComposer({
   http.Client? client,
 }) {
   if (geminiApiKey.trim().isEmpty) return const LocalEchoComposer();
-  return GeminiEchoComposer(apiKey: geminiApiKey, systemPrompt: systemPrompt, client: client);
+  return GeminiEchoComposer(
+    apiKey: geminiApiKey,
+    systemPrompt: systemPrompt,
+    client: client,
+  );
 }
 
 class LocalEchoComposer implements EchoComposer {
@@ -64,15 +68,46 @@ class LocalEchoComposer implements EchoComposer {
 
   static String _family(String lower) {
     bool has(List<String> needles) => needles.any(lower.contains);
-    if (has(const ['sad', 'sorrow', 'grief', 'lonely', 'alone', 'miss you', 'despair', 'cry', 'hurt'])) {
+    if (has(const [
+      'sad',
+      'sorrow',
+      'grief',
+      'lonely',
+      'alone',
+      'miss you',
+      'despair',
+      'cry',
+      'hurt',
+    ])) {
       return 'sorrow';
     }
-    if (has(const ['problem', 'stuck', 'fail', 'wrong', 'broken', 'worry', 'anxi', 'fear', 'afraid', 'issue'])) {
+    if (has(const [
+      'problem',
+      'stuck',
+      'fail',
+      'wrong',
+      'broken',
+      'worry',
+      'anxi',
+      'fear',
+      'afraid',
+      'issue',
+    ])) {
       return 'trouble';
     }
-    if (has(const ['angry', 'anger', 'rage', 'hate', 'furious'])) return 'anger';
-    if (has(const ['private', 'secret', 'hidden', 'hide', 'unseen'])) return 'privacy';
-    if (has(const ['lost', 'unsure', 'maybe', "don't know", 'perhaps', 'confused'])) return 'doubt';
+    if (has(const ['angry', 'anger', 'rage', 'hate', 'furious']))
+      return 'anger';
+    if (has(const ['private', 'secret', 'hidden', 'hide', 'unseen']))
+      return 'privacy';
+    if (has(const [
+      'lost',
+      'unsure',
+      'maybe',
+      "don't know",
+      'perhaps',
+      'confused',
+    ]))
+      return 'doubt';
     if (has(const ['love', 'dear', 'miss', 'heart'])) return 'tender';
     if (has(const ['hope', 'wish', 'want', 'need'])) return 'longing';
     return 'still';
@@ -170,10 +205,7 @@ class GeminiEchoComposer implements EchoComposer {
                   ],
                 },
               ],
-              'generationConfig': {
-                'temperature': 0.6,
-                'maxOutputTokens': 160,
-              },
+              'generationConfig': {'temperature': 0.6, 'maxOutputTokens': 160},
             }),
           )
           .timeout(timeout);
@@ -216,7 +248,11 @@ class GeminiEchoComposer implements EchoComposer {
 }
 
 String clipWords(String text, {int max = 60}) {
-  final words = text.trim().split(RegExp(r'\s+')).where((word) => word.isNotEmpty).toList();
+  final words = text
+      .trim()
+      .split(RegExp(r'\s+'))
+      .where((word) => word.isNotEmpty)
+      .toList();
   if (words.length <= max) return words.join(' ');
   return '${words.take(max).join(' ')}…';
 }

--- a/lib/features/canvas/presentation/canvas_page.dart
+++ b/lib/features/canvas/presentation/canvas_page.dart
@@ -10,6 +10,9 @@ import '../../../core/a11y/motion.dart';
 import '../../../shared/widgets/chrome.dart';
 import '../../boards/domain/board.dart';
 import '../../boards/domain/echo_pairing.dart';
+import '../../boards/domain/node_motion.dart';
+import '../../privacy/domain/privacy_models.dart';
+import 'paper_slip.dart';
 
 class CanvasPage extends ConsumerStatefulWidget {
   const CanvasPage({required this.boardId, super.key});
@@ -27,7 +30,8 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
   String? _summonError;
   int _focusedIndex = 0;
   bool _summoning = false;
-  bool _echoConsentedThisSession = false;
+  bool _echoConsented = false;
+  bool _dragging = false;
   final _note = TextEditingController();
   final _seen = <String>{};
 
@@ -59,11 +63,16 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
     final canvas = ref.read(canvasRepositoryProvider);
     final board = await boards.getById(widget.boardId);
     final nodes = await canvas.listNodes(widget.boardId);
+    final consents = await ref.read(privacyRepositoryProvider).consents();
     if (!mounted) return;
     setState(() {
       _board = board.okOrNull;
       _error = board.errOrNull?.message ?? nodes.errOrNull?.message;
       _nodes = nodes.okOrNull ?? [];
+      _echoConsented = hasGrantedConsent(
+        consents.okOrNull ?? const [],
+        ConsentKind.remoteEcho,
+      );
       _seen.addAll(_nodes.map((n) => n.id));
     });
     await _untangleEchoes();
@@ -103,8 +112,14 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
       if (swatch.kind != NodeKind.swatch) continue;
       for (final echo in next) {
         if (echo.kind != NodeKind.echo) continue;
-        if ((swatch.x - echo.x).abs() < 200 && (swatch.y - echo.y).abs() < 110) {
-          await persist(swatch.copyWith(x: echo.x + EchoPairing.slipWidth + 36, y: swatch.y));
+        if ((swatch.x - echo.x).abs() < 200 &&
+            (swatch.y - echo.y).abs() < 110) {
+          await persist(
+            swatch.copyWith(
+              x: echo.x + EchoPairing.slipWidth + 36,
+              y: swatch.y,
+            ),
+          );
           break;
         }
       }
@@ -113,7 +128,13 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
     if (changed && mounted) setState(() => _nodes = next);
   }
 
+  bool get _restricted => _board?.restricted == true;
+
   Future<void> _addNote() async {
+    if (_restricted) {
+      announce(context, 'This board is restricted (Art. 18).');
+      return;
+    }
     final text = _note.text.trim();
     if (text.isEmpty) return;
     final humans = _nodes.where((n) => n.kind == NodeKind.text).length;
@@ -143,6 +164,10 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
   }
 
   Future<void> _addSwatch() async {
+    if (_restricted) {
+      announce(context, 'This board is restricted (Art. 18).');
+      return;
+    }
     const colors = [0xFF1F4E5A, 0xFFC45C26, 0xFF2C2C2C, 0xFFE8DCC8];
     final node = BoardNode(
       id: const Uuid().v4(),
@@ -161,28 +186,34 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
   }
 
   Future<void> _nudge(int dx, int dy) async {
-    if (_nodes.isEmpty) return;
-    final node = _nodes[_focusedIndex.clamp(0, _nodes.length - 1)];
-    final moved = node.copyWith(x: node.x + dx, y: node.y + dy);
-    final canvas = ref.read(canvasRepositoryProvider);
-    final result = await canvas.upsert(moved);
-    var next = [for (final n in _nodes) n.id == moved.id ? moved : n];
-    result.when(
-      ok: (updated) => next = [for (final n in next) n.id == updated.id ? updated : n],
-      err: (_) {},
-    );
-    if (node.kind == NodeKind.text) {
-      final echo = EchoPairing.echoFor(_nodes, node.id);
-      if (echo != null) {
-        final shifted = echo.copyWith(x: echo.x + dx, y: echo.y + dy);
-        final echoResult = await canvas.upsert(shifted);
-        echoResult.when(
-          ok: (updated) => next = [for (final n in next) n.id == updated.id ? updated : n],
-          err: (_) {},
-        );
-      }
+    if (_nodes.isEmpty || _restricted) {
+      if (_restricted) announce(context, 'This board is restricted (Art. 18).');
+      return;
     }
-    if (mounted) setState(() => _nodes = next);
+    final node = _nodes[_focusedIndex.clamp(0, _nodes.length - 1)];
+    await _persistMove(node.id, dx.toDouble(), dy.toDouble());
+  }
+
+  Future<void> _persistMove(String id, double dx, double dy) async {
+    if (dx == 0 && dy == 0) return;
+    final previous = List<BoardNode>.from(_nodes);
+    final next = NodeMotion.moved(previous, id: id, dx: dx, dy: dy);
+    if (identical(next, previous)) return;
+    setState(() => _nodes = next);
+    final canvas = ref.read(canvasRepositoryProvider);
+    String? error;
+    for (final node in next) {
+      final old = previous.firstWhere((item) => item.id == node.id);
+      if (old.x == node.x && old.y == node.y) continue;
+      final result = await canvas.upsert(node);
+      result.when(ok: (_) {}, err: (failure) => error = failure.message);
+    }
+    if (!mounted) return;
+    if (error != null) {
+      announce(context, error!);
+      return;
+    }
+    await _untangleEchoes();
   }
 
   Future<bool> _confirmRemoteEcho() async {
@@ -212,13 +243,26 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
   }
 
   Future<void> _summonEcho() async {
+    if (_restricted) {
+      announce(context, 'This board is restricted (Art. 18).');
+      return;
+    }
     final parent = _selected;
-    if (parent == null || !EchoPairing.canSummon(parent, _nodes) || _summoning) return;
+    if (parent == null || !EchoPairing.canSummon(parent, _nodes) || _summoning)
+      return;
     final composer = ref.read(echoComposerProvider);
-    if (composer.remote && !_echoConsentedThisSession) {
+    if (composer.remote && !_echoConsented) {
       final agreed = await _confirmRemoteEcho();
       if (!mounted || !agreed) return;
-      _echoConsentedThisSession = true;
+      final recorded = await ref
+          .read(privacyRepositoryProvider)
+          .recordConsent(ConsentKind.remoteEcho, granted: true);
+      if (!mounted) return;
+      recorded.when(
+        ok: (_) => _echoConsented = true,
+        err: (failure) => announce(context, failure.message),
+      );
+      if (!_echoConsented) return;
     }
     setState(() {
       _summoning = true;
@@ -272,7 +316,10 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
     result.when(
       ok: (_) {
         setState(() {
-          _nodes = [for (final n in _nodes) if (n.id != id) n];
+          _nodes = [
+            for (final n in _nodes)
+              if (n.id != id) n,
+          ];
           if (_nodes.isEmpty) {
             _focusedIndex = 0;
           } else {
@@ -283,6 +330,108 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
       },
       err: (failure) => announce(context, failure.message),
     );
+  }
+
+  Future<void> _saveText(BoardNode node, String text) async {
+    if (_restricted) {
+      announce(context, 'This board is restricted (Art. 18).');
+      return;
+    }
+    final result = await ref
+        .read(canvasRepositoryProvider)
+        .upsert(node.copyWith(text: text));
+    if (!mounted) return;
+    result.when(
+      ok: (updated) {
+        setState(
+          () => _nodes = [
+            for (final item in _nodes) item.id == updated.id ? updated : item,
+          ],
+        );
+        announce(context, 'Note saved.');
+      },
+      err: (failure) => announce(context, failure.message),
+    );
+  }
+
+  Future<void> _deleteHuman(BoardNode node) async {
+    if (_restricted) {
+      announce(context, 'This board is restricted (Art. 18).');
+      return;
+    }
+    final confirmed = await showFDialog<bool>(
+      context: context,
+      builder: (context, style, animation) => FDialog(
+        animation: animation,
+        title: const Text('Remove this slip'),
+        body: const Text(
+          'The note and its echo, if any, will be removed from this board.',
+        ),
+        actions: [
+          FButton(
+            variant: FButtonVariant.destructive,
+            onPress: () => Navigator.of(context).pop(true),
+            child: const Text('Delete this note'),
+          ),
+          FButton(
+            variant: FButtonVariant.outline,
+            onPress: () => Navigator.of(context).pop(false),
+            child: const Text('Keep it'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    final result = await ref.read(canvasRepositoryProvider).delete(node.id);
+    if (!mounted) return;
+    result.when(
+      ok: (_) {
+        setState(() {
+          _nodes = [
+            for (final item in _nodes)
+              if (item.id != node.id && item.parentId != node.id) item,
+          ];
+          if (_nodes.isEmpty) {
+            _focusedIndex = 0;
+          } else {
+            _focusedIndex = _focusedIndex.clamp(0, _nodes.length - 1);
+          }
+        });
+        announce(context, 'Note deleted.');
+      },
+      err: (failure) => announce(context, failure.message),
+    );
+  }
+
+  void _acknowledgePhrase() {
+    ref.read(authRepositoryProvider).acknowledgeRecoveryPhrase();
+    announce(context, 'Recovery phrase saved.');
+    setState(() {});
+  }
+
+  Future<void> _commitDrag(String id) async {
+    setState(() => _dragging = false);
+    final canvas = ref.read(canvasRepositoryProvider);
+    final node = _nodes.where((item) => item.id == id);
+    if (node.isEmpty) return;
+    String? error;
+    Future<void> save(BoardNode value) async {
+      final result = await canvas.upsert(value);
+      result.when(ok: (_) {}, err: (failure) => error = failure.message);
+    }
+
+    await save(node.first);
+    if (node.first.kind == NodeKind.text) {
+      final echo = EchoPairing.echoFor(_nodes, id);
+      if (echo != null) await save(echo);
+    }
+    if (!mounted) return;
+    if (error != null) {
+      announce(context, error!);
+      return;
+    }
+    announce(context, 'Moved');
+    await _untangleEchoes();
   }
 
   bool get _highContrast {
@@ -296,7 +445,12 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
     final phrase = ref.watch(authRepositoryProvider).pendingRecoveryPhrase;
     if (_error != null) {
       return PenumbraChrome(
-        child: PenumbraPage(child: FAlert(variant: FAlertVariant.destructive, title: Text(_error!))),
+        child: PenumbraPage(
+          child: FAlert(
+            variant: FAlertVariant.destructive,
+            title: Text(_error!),
+          ),
+        ),
       );
     }
     if (_board == null) {
@@ -305,10 +459,13 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
 
     return CallbackShortcuts(
       bindings: {
-        const SingleActivator(LogicalKeyboardKey.arrowLeft): () => _nudge(-16, 0),
-        const SingleActivator(LogicalKeyboardKey.arrowRight): () => _nudge(16, 0),
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): () =>
+            _nudge(-16, 0),
+        const SingleActivator(LogicalKeyboardKey.arrowRight): () =>
+            _nudge(16, 0),
         const SingleActivator(LogicalKeyboardKey.arrowUp): () => _nudge(0, -16),
-        const SingleActivator(LogicalKeyboardKey.arrowDown): () => _nudge(0, 16),
+        const SingleActivator(LogicalKeyboardKey.arrowDown): () =>
+            _nudge(0, 16),
       },
       child: Focus(
         autofocus: true,
@@ -326,17 +483,42 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
                 highContrast: _highContrast,
                 phrase: phrase,
                 summonError: _summonError,
+                panEnabled: !_dragging,
                 appear: _appear,
                 onFocus: (id) => setState(() {
                   final i = _nodes.indexWhere((n) => n.id == id);
                   if (i >= 0) _focusedIndex = i;
                 }),
-                onDismissEcho: _dismissEcho,
+                onDismissEcho: _restricted ? null : _dismissEcho,
+                onAcknowledgePhrase: _acknowledgePhrase,
+                onSaveText: _restricted
+                    ? null
+                    : (node, text) => _saveText(node, text),
+                onDelete: _restricted ? null : _deleteHuman,
+                onDragStart: _restricted
+                    ? null
+                    : (id) => setState(() {
+                        _dragging = true;
+                        final i = _nodes.indexWhere((n) => n.id == id);
+                        if (i >= 0) _focusedIndex = i;
+                      }),
+                onDrag: _restricted
+                    ? null
+                    : (id, delta) => setState(() {
+                        _nodes = NodeMotion.moved(
+                          _nodes,
+                          id: id,
+                          dx: delta.dx,
+                          dy: delta.dy,
+                        );
+                      }),
+                onDragEnd: _restricted ? null : _commitDrag,
                 toolbar: _ComposeBar(
                   controller: _note,
+                  enabled: !_restricted,
                   onPlace: _addNote,
                   onSwatch: _addSwatch,
-                  onSummon: _canSummon ? _summonEcho : null,
+                  onSummon: !_restricted && _canSummon ? _summonEcho : null,
                   summoning: _summoning,
                 ),
               );
@@ -379,14 +561,26 @@ class _CanvasPageState extends ConsumerState<CanvasPage> {
   }
 }
 
-List<BoardNode> _paintOrder(List<BoardNode> nodes, List<BoardNode> conversation, String? focusedId) {
-  final humans = [for (final node in conversation) if (node.kind != NodeKind.echo) node];
-  final echoes = [for (final node in conversation) if (node.kind == NodeKind.echo) node];
+List<BoardNode> _paintOrder(
+  List<BoardNode> nodes,
+  List<BoardNode> conversation,
+  String? focusedId,
+) {
+  final humans = [
+    for (final node in conversation)
+      if (node.kind != NodeKind.echo) node,
+  ];
+  final echoes = [
+    for (final node in conversation)
+      if (node.kind == NodeKind.echo) node,
+  ];
   final ordered = [...humans, ...echoes];
   if (focusedId == null) return ordered;
   return [
-    for (final node in ordered) if (node.id != focusedId) node,
-    for (final node in nodes) if (node.id == focusedId) node,
+    for (final node in ordered)
+      if (node.id != focusedId) node,
+    for (final node in nodes)
+      if (node.id == focusedId) node,
   ];
 }
 
@@ -399,9 +593,16 @@ class _Atelier extends StatelessWidget {
     required this.highContrast,
     required this.phrase,
     required this.summonError,
+    required this.panEnabled,
     required this.appear,
     required this.onFocus,
     required this.onDismissEcho,
+    required this.onAcknowledgePhrase,
+    required this.onSaveText,
+    required this.onDelete,
+    required this.onDragStart,
+    required this.onDrag,
+    required this.onDragEnd,
     required this.toolbar,
   });
 
@@ -412,15 +613,26 @@ class _Atelier extends StatelessWidget {
   final bool highContrast;
   final String? phrase;
   final String? summonError;
+  final bool panEnabled;
   final Widget Function(String id, Widget child) appear;
   final ValueChanged<String> onFocus;
-  final ValueChanged<String> onDismissEcho;
+  final ValueChanged<String>? onDismissEcho;
+  final VoidCallback onAcknowledgePhrase;
+  final void Function(BoardNode node, String text)? onSaveText;
+  final ValueChanged<BoardNode>? onDelete;
+  final ValueChanged<String>? onDragStart;
+  final void Function(String id, Offset delta)? onDrag;
+  final ValueChanged<String>? onDragEnd;
   final Widget toolbar;
 
   @override
   Widget build(BuildContext context) {
     final theme = context.theme;
-    final well = Color.lerp(theme.colors.background, theme.colors.foreground, 0.04)!;
+    final well = Color.lerp(
+      theme.colors.background,
+      theme.colors.foreground,
+      0.04,
+    )!;
     return ColoredBox(
       color: well,
       child: Padding(
@@ -435,10 +647,30 @@ class _Atelier extends StatelessWidget {
                   '$phrase\nOAuth and passkey accounts wrap your key with this phrase. We cannot recover it.',
                 ),
               ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: FButton(
+                  onPress: onAcknowledgePhrase,
+                  child: const Text('I have saved this phrase'),
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+            if (board.restricted) ...[
+              const FAlert(
+                title: Text('This board is restricted (Art. 18).'),
+                subtitle: Text(
+                  'Place, edit, delete, and move are paused until you unrestrict it.',
+                ),
+              ),
               const SizedBox(height: 12),
             ],
             if (summonError != null) ...[
-              FAlert(variant: FAlertVariant.destructive, title: Text(summonError!)),
+              FAlert(
+                variant: FAlertVariant.destructive,
+                title: Text(summonError!),
+              ),
               const SizedBox(height: 12),
             ],
             _RunningHead(title: board.title, count: nodes.length),
@@ -453,12 +685,16 @@ class _Atelier extends StatelessWidget {
                       ? const []
                       : [
                           BoxShadow(
-                            color: theme.colors.foreground.withValues(alpha: 0.18),
+                            color: theme.colors.foreground.withValues(
+                              alpha: 0.18,
+                            ),
                             blurRadius: 40,
                             offset: const Offset(0, 18),
                           ),
                           BoxShadow(
-                            color: theme.colors.foreground.withValues(alpha: 0.06),
+                            color: theme.colors.foreground.withValues(
+                              alpha: 0.06,
+                            ),
                             blurRadius: 4,
                             offset: const Offset(0, 1),
                           ),
@@ -467,6 +703,7 @@ class _Atelier extends StatelessWidget {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(4),
                   child: InteractiveViewer(
+                    panEnabled: panEnabled,
                     constrained: false,
                     minScale: 0.5,
                     maxScale: 2.5,
@@ -493,19 +730,46 @@ class _Atelier extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            for (final node in _paintOrder(nodes, conversation, focusedId))
+                            for (final node in _paintOrder(
+                              nodes,
+                              conversation,
+                              focusedId,
+                            ))
                               Positioned(
                                 left: node.x,
                                 top: node.y,
                                 child: appear(
                                   node.id,
-                                  _PaperSlip(
+                                  PaperSlip(
                                     node: node,
-                                    numeral: EchoPairing.numeral(conversation, node),
+                                    numeral: EchoPairing.numeral(
+                                      conversation,
+                                      node,
+                                    ),
                                     selected: node.id == focusedId,
                                     highContrast: highContrast,
+                                    readOnly: board.restricted,
                                     onFocus: () => onFocus(node.id),
-                                    onDismiss: node.kind == NodeKind.echo ? () => onDismissEcho(node.id) : null,
+                                    onDismiss:
+                                        node.kind == NodeKind.echo &&
+                                            onDismissEcho != null
+                                        ? () => onDismissEcho!(node.id)
+                                        : null,
+                                    onSaveText: onSaveText == null
+                                        ? null
+                                        : (text) => onSaveText!(node, text),
+                                    onDelete: onDelete == null
+                                        ? null
+                                        : () => onDelete!(node),
+                                    onDragStart: onDragStart == null
+                                        ? null
+                                        : () => onDragStart!(node.id),
+                                    onDrag: onDrag == null
+                                        ? null
+                                        : (delta) => onDrag!(node.id, delta),
+                                    onDragEnd: onDragEnd == null
+                                        ? null
+                                        : () => onDragEnd!(node.id),
                                   ),
                                 ),
                               ),
@@ -579,6 +843,7 @@ class _ComposeBar extends StatelessWidget {
     required this.onSwatch,
     required this.onSummon,
     required this.summoning,
+    this.enabled = true,
   });
 
   final TextEditingController controller;
@@ -586,6 +851,7 @@ class _ComposeBar extends StatelessWidget {
   final VoidCallback onSwatch;
   final VoidCallback? onSummon;
   final bool summoning;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -612,20 +878,32 @@ class _ComposeBar extends StatelessWidget {
               final tight = constraints.maxWidth < 620;
               final field = FTextField(
                 hint: 'A thought, privately held',
+                enabled: enabled,
                 control: FTextFieldControl.managed(controller: controller),
               );
               final actions = Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  FButton(onPress: onPlace, child: const Text('Place')),
-                  FButton(variant: FButtonVariant.outline, onPress: onSwatch, child: const Text('Swatch')),
+                  FButton(
+                    onPress: enabled ? onPlace : null,
+                    child: const Text('Place'),
+                  ),
+                  FButton(
+                    variant: FButtonVariant.outline,
+                    onPress: enabled ? onSwatch : null,
+                    child: const Text('Swatch'),
+                  ),
                   if (onSummon != null || summoning)
                     FButton(
                       variant: FButtonVariant.outline,
-                      onPress: summoning ? null : onSummon,
+                      onPress: summoning || !enabled ? null : onSummon,
                       prefix: summoning
-                          ? const SizedBox(width: 14, height: 14, child: FCircularProgress())
+                          ? const SizedBox(
+                              width: 14,
+                              height: 14,
+                              child: FCircularProgress(),
+                            )
                           : null,
                       child: const Text('Summon an echo'),
                     ),
@@ -634,11 +912,7 @@ class _ComposeBar extends StatelessWidget {
               if (tight) {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    field,
-                    const SizedBox(height: 8),
-                    actions,
-                  ],
+                  children: [field, const SizedBox(height: 8), actions],
                 );
               }
               return Row(
@@ -655,7 +929,11 @@ class _ComposeBar extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: SizedBox(
                       height: 28,
-                      child: VerticalDivider(width: 1, thickness: 1, color: theme.colors.border),
+                      child: VerticalDivider(
+                        width: 1,
+                        thickness: 1,
+                        color: theme.colors.border,
+                      ),
                     ),
                   ),
                   Expanded(child: field),
@@ -691,8 +969,12 @@ class _CardIndex extends StatelessWidget {
       decoration: BoxDecoration(
         color: theme.colors.background,
         border: Border(
-          left: stacked ? BorderSide.none : BorderSide(color: theme.colors.border),
-          top: stacked ? BorderSide(color: theme.colors.border) : BorderSide.none,
+          left: stacked
+              ? BorderSide.none
+              : BorderSide(color: theme.colors.border),
+          top: stacked
+              ? BorderSide(color: theme.colors.border)
+              : BorderSide.none,
         ),
       ),
       child: Padding(
@@ -709,8 +991,11 @@ class _CardIndex extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              'A conversation. Arrow keys move the selected slip.',
-              style: theme.typography.xs.copyWith(color: theme.colors.mutedForeground, height: 1.4),
+              'A conversation. Arrow keys or Move reposition the selected slip.',
+              style: theme.typography.xs.copyWith(
+                color: theme.colors.mutedForeground,
+                height: 1.4,
+              ),
             ),
             const SizedBox(height: 8),
             DecoratedBox(
@@ -740,13 +1025,20 @@ class _CardIndex extends StatelessWidget {
                         decoration: BoxDecoration(
                           border: Border(
                             left: BorderSide(
-                              color: selected ? theme.colors.primary : Colors.transparent,
+                              color: selected
+                                  ? theme.colors.primary
+                                  : Colors.transparent,
                               width: 2,
                             ),
                           ),
                         ),
                         child: Padding(
-                          padding: EdgeInsets.fromLTRB(echo ? 28 : 12, 12, 8, 12),
+                          padding: EdgeInsets.fromLTRB(
+                            echo ? 28 : 12,
+                            12,
+                            8,
+                            12,
+                          ),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
@@ -754,19 +1046,27 @@ class _CardIndex extends StatelessWidget {
                                 numeral,
                                 style: theme.typography.xs.copyWith(
                                   fontFamily: PenumbraInk.displayFamily,
-                                  fontStyle: echo ? FontStyle.italic : FontStyle.normal,
-                                  color: selected ? theme.colors.primary : theme.colors.mutedForeground,
+                                  fontStyle: echo
+                                      ? FontStyle.italic
+                                      : FontStyle.normal,
+                                  color: selected
+                                      ? theme.colors.primary
+                                      : theme.colors.mutedForeground,
                                   letterSpacing: 0.8,
                                 ),
                               ),
                               const SizedBox(height: 2),
                               Text(
-                                echo ? (node.text ?? 'Echo') : node.semanticsLabel,
+                                echo
+                                    ? (node.text ?? 'Echo')
+                                    : node.semanticsLabel,
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
                                 style: theme.typography.sm.copyWith(
                                   fontFamily: PenumbraInk.displayFamily,
-                                  fontStyle: echo ? FontStyle.italic : FontStyle.normal,
+                                  fontStyle: echo
+                                      ? FontStyle.italic
+                                      : FontStyle.normal,
                                   height: 1.3,
                                 ),
                               ),
@@ -780,157 +1080,6 @@ class _CardIndex extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PaperSlip extends StatelessWidget {
-  const _PaperSlip({
-    required this.node,
-    required this.numeral,
-    required this.selected,
-    required this.highContrast,
-    required this.onFocus,
-    this.onDismiss,
-  });
-
-  final BoardNode node;
-  final String numeral;
-  final bool selected;
-  final bool highContrast;
-  final VoidCallback onFocus;
-  final VoidCallback? onDismiss;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = context.theme;
-    final echo = node.kind == NodeKind.echo;
-    final slip = ConstrainedBox(
-      constraints: BoxConstraints(minWidth: echo ? 168 : 176, maxWidth: echo ? 240 : 260),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: theme.colors.background,
-          borderRadius: BorderRadius.circular(3),
-          border: Border.all(
-            color: selected
-                ? theme.colors.primary
-                : echo
-                ? theme.colors.primary.withValues(alpha: highContrast ? 1 : 0.45)
-                : theme.colors.border,
-            width: selected ? 1.5 : 1,
-          ),
-          boxShadow: highContrast || echo
-              ? const []
-              : [
-                  BoxShadow(
-                    color: theme.colors.foreground.withValues(alpha: selected ? 0.16 : 0.08),
-                    blurRadius: selected ? 22 : 14,
-                    offset: const Offset(0, 10),
-                  ),
-                  BoxShadow(
-                    color: theme.colors.foreground.withValues(alpha: 0.04),
-                    blurRadius: 2,
-                    offset: const Offset(0, 1),
-                  ),
-                ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    numeral,
-                    style: theme.typography.xs.copyWith(
-                      fontFamily: PenumbraInk.displayFamily,
-                      fontStyle: echo ? FontStyle.italic : FontStyle.normal,
-                      color: selected ? theme.colors.primary : theme.colors.mutedForeground,
-                      letterSpacing: 1,
-                    ),
-                  ),
-                  const Spacer(),
-                  if (echo && selected && onDismiss != null)
-                    Semantics(
-                      button: true,
-                      label: 'Dismiss this echo',
-                      child: GestureDetector(
-                        onTap: onDismiss,
-                        child: Text(
-                          'Dismiss',
-                          style: theme.typography.xs.copyWith(
-                            color: theme.colors.primary,
-                            letterSpacing: 0.6,
-                          ),
-                        ),
-                      ),
-                    )
-                  else if (selected)
-                    Container(
-                      width: 6,
-                      height: 6,
-                      decoration: BoxDecoration(color: theme.colors.primary, shape: BoxShape.circle),
-                    ),
-                ],
-              ),
-              const SizedBox(height: 10),
-              if (node.kind == NodeKind.swatch)
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    ColoredBox(
-                      color: Color(node.colorArgb ?? 0xFF000000),
-                      child: const SizedBox(width: 132, height: 88),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'Specimen',
-                      style: theme.typography.xs.copyWith(
-                        color: theme.colors.mutedForeground,
-                        letterSpacing: 0.8,
-                      ),
-                    ),
-                  ],
-                )
-              else
-                Text(
-                  node.text ?? (echo ? 'Echo' : 'Untitled note'),
-                  style: theme.typography.md.copyWith(
-                    fontFamily: PenumbraInk.displayFamily,
-                    fontStyle: echo ? FontStyle.italic : FontStyle.normal,
-                    height: 1.35,
-                    fontWeight: echo ? FontWeight.w400 : FontWeight.w500,
-                    color: echo ? theme.colors.mutedForeground : theme.colors.foreground,
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    return Semantics(
-      button: true,
-      selected: selected,
-      label: echo ? '${node.semanticsLabel}, $numeral' : 'Card $numeral, ${node.semanticsLabel}',
-      child: Focus(
-        onFocusChange: (hasFocus) {
-          if (hasFocus) onFocus();
-        },
-        child: GestureDetector(
-          onTap: onFocus,
-          child: selected && !highContrast && !echo
-              ? DecoratedBox(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: theme.colors.primary.withValues(alpha: 0.45)),
-                  ),
-                  child: Padding(padding: const EdgeInsets.all(5), child: slip),
-                )
-              : slip,
         ),
       ),
     );
@@ -960,7 +1109,10 @@ class _EchoHairlinePainter extends CustomPainter {
       }
       if (parent == null) continue;
       canvas.drawLine(
-        Offset(parent.x + EchoPairing.slipWidth, parent.y + EchoPairing.slipHeight * 0.45),
+        Offset(
+          parent.x + EchoPairing.slipWidth,
+          parent.y + EchoPairing.slipHeight * 0.45,
+        ),
         Offset(echo.x, echo.y + 36),
         paint,
       );
@@ -992,15 +1144,23 @@ class _SheetPainter extends CustomPainter {
     canvas.drawRect(Offset.zero & size, Paint()..color = paper);
 
     const inset = 36.0;
-    final plate = Rect.fromLTWH(inset, inset, size.width - inset * 2, size.height - inset * 2);
+    final plate = Rect.fromLTWH(
+      inset,
+      inset,
+      size.width - inset * 2,
+      size.height - inset * 2,
+    );
     final rulePaint = Paint()
       ..color = rule
       ..strokeWidth = 1;
 
-    canvas.drawRect(plate, Paint()
-      ..color = rule
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.8);
+    canvas.drawRect(
+      plate,
+      Paint()
+        ..color = rule
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 0.8,
+    );
 
     _crop(canvas, plate.topLeft, 1, 1, rulePaint);
     _crop(canvas, plate.topRight, -1, 1, rulePaint);
@@ -1028,7 +1188,11 @@ class _SheetPainter extends CustomPainter {
         ..strokeWidth = 0.6;
       const step = 28.0;
       for (var y = plate.top + 48; y < plate.bottom - 8; y += step) {
-        canvas.drawLine(Offset(plate.left + 16, y), Offset(plate.right - 16, y), line);
+        canvas.drawLine(
+          Offset(plate.left + 16, y),
+          Offset(plate.right - 16, y),
+          line,
+        );
       }
       final dots = Paint()..color = rule;
       for (var x = plate.left + 16; x < plate.right - 8; x += step) {

--- a/lib/features/canvas/presentation/paper_slip.dart
+++ b/lib/features/canvas/presentation/paper_slip.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../../app/theme.dart';
+import '../../boards/domain/board.dart';
+
+class PaperSlip extends StatefulWidget {
+  const PaperSlip({
+    required this.node,
+    required this.numeral,
+    required this.selected,
+    required this.highContrast,
+    required this.readOnly,
+    required this.onFocus,
+    this.onDismiss,
+    this.onSaveText,
+    this.onDelete,
+    this.onDragStart,
+    this.onDrag,
+    this.onDragEnd,
+    super.key,
+  });
+
+  final BoardNode node;
+  final String numeral;
+  final bool selected;
+  final bool highContrast;
+  final bool readOnly;
+  final VoidCallback onFocus;
+  final VoidCallback? onDismiss;
+  final ValueChanged<String>? onSaveText;
+  final VoidCallback? onDelete;
+  final VoidCallback? onDragStart;
+  final ValueChanged<Offset>? onDrag;
+  final VoidCallback? onDragEnd;
+
+  @override
+  State<PaperSlip> createState() => _PaperSlipState();
+}
+
+class _PaperSlipState extends State<PaperSlip> {
+  var _editing = false;
+  late final TextEditingController _edit = TextEditingController(
+    text: widget.node.text ?? '',
+  );
+
+  @override
+  void didUpdateWidget(covariant PaperSlip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_editing && oldWidget.node.text != widget.node.text) {
+      _edit.text = widget.node.text ?? '';
+    }
+    if (!widget.selected) _editing = false;
+  }
+
+  @override
+  void dispose() {
+    _edit.dispose();
+    super.dispose();
+  }
+
+  bool get _human => widget.node.kind != NodeKind.echo;
+  bool get _echo => widget.node.kind == NodeKind.echo;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    final echo = _echo;
+    final selected = widget.selected;
+    final highContrast = widget.highContrast;
+    final slip = ConstrainedBox(
+      constraints: BoxConstraints(
+        minWidth: echo ? 168 : 176,
+        maxWidth: echo ? 240 : 280,
+      ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colors.background,
+          borderRadius: BorderRadius.circular(3),
+          border: Border.all(
+            color: selected
+                ? theme.colors.primary
+                : echo
+                ? theme.colors.primary.withValues(
+                    alpha: highContrast ? 1 : 0.45,
+                  )
+                : theme.colors.border,
+            width: selected ? 1.5 : 1,
+          ),
+          boxShadow: highContrast || echo
+              ? const []
+              : [
+                  BoxShadow(
+                    color: theme.colors.foreground.withValues(
+                      alpha: selected ? 0.16 : 0.08,
+                    ),
+                    blurRadius: selected ? 22 : 14,
+                    offset: const Offset(0, 10),
+                  ),
+                  BoxShadow(
+                    color: theme.colors.foreground.withValues(alpha: 0.04),
+                    blurRadius: 2,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    widget.numeral,
+                    style: theme.typography.xs.copyWith(
+                      fontFamily: PenumbraInk.displayFamily,
+                      fontStyle: echo ? FontStyle.italic : FontStyle.normal,
+                      color: selected
+                          ? theme.colors.primary
+                          : theme.colors.mutedForeground,
+                      letterSpacing: 1,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (echo && selected && widget.onDismiss != null)
+                    _namedAction(
+                      theme,
+                      label: 'Dismiss',
+                      spoken: 'Dismiss this echo',
+                      onTap: widget.onDismiss!,
+                    )
+                  else if (selected && !_editing)
+                    Container(
+                      width: 6,
+                      height: 6,
+                      decoration: BoxDecoration(
+                        color: theme.colors.primary,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              if (widget.node.kind == NodeKind.swatch)
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ColoredBox(
+                      color: Color(widget.node.colorArgb ?? 0xFF000000),
+                      child: const SizedBox(width: 132, height: 88),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Specimen',
+                      style: theme.typography.xs.copyWith(
+                        color: theme.colors.mutedForeground,
+                        letterSpacing: 0.8,
+                      ),
+                    ),
+                  ],
+                )
+              else if (_editing)
+                FTextField(
+                  hint: 'A thought, privately held',
+                  control: FTextFieldControl.managed(controller: _edit),
+                )
+              else
+                Text(
+                  widget.node.text ?? (echo ? 'Echo' : 'Untitled note'),
+                  style: theme.typography.md.copyWith(
+                    fontFamily: PenumbraInk.displayFamily,
+                    fontStyle: echo ? FontStyle.italic : FontStyle.normal,
+                    height: 1.35,
+                    fontWeight: echo ? FontWeight.w400 : FontWeight.w500,
+                    color: echo
+                        ? theme.colors.mutedForeground
+                        : theme.colors.foreground,
+                  ),
+                ),
+              if (selected && _human && !widget.readOnly) ...[
+                const SizedBox(height: 10),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 4,
+                  children: [
+                    if (widget.node.kind == NodeKind.text &&
+                        widget.onSaveText != null)
+                      _editing
+                          ? _namedAction(
+                              theme,
+                              label: 'Save',
+                              spoken: 'Save this note',
+                              onTap: () {
+                                final text = _edit.text.trim();
+                                if (text.isEmpty) return;
+                                widget.onSaveText!(text);
+                                setState(() => _editing = false);
+                              },
+                            )
+                          : _namedAction(
+                              theme,
+                              label: 'Edit',
+                              spoken: 'Edit this note',
+                              onTap: () => setState(() {
+                                _edit.text = widget.node.text ?? '';
+                                _editing = true;
+                              }),
+                            ),
+                    if (_editing)
+                      _namedAction(
+                        theme,
+                        label: 'Cancel',
+                        spoken: 'Cancel editing',
+                        onTap: () => setState(() => _editing = false),
+                      ),
+                    if (!_editing && widget.onDelete != null)
+                      _namedAction(
+                        theme,
+                        label: 'Delete',
+                        spoken: 'Delete this note',
+                        onTap: widget.onDelete!,
+                      ),
+                    if (!_editing && widget.onDrag != null) _moveHandle(theme),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: echo
+          ? '${widget.node.semanticsLabel}, ${widget.numeral}'
+          : 'Card ${widget.numeral}, ${widget.node.semanticsLabel}',
+      child: Focus(
+        onFocusChange: (hasFocus) {
+          if (hasFocus) widget.onFocus();
+        },
+        child: GestureDetector(
+          onTap: widget.onFocus,
+          child: selected && !highContrast && !echo
+              ? DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: theme.colors.primary.withValues(alpha: 0.45),
+                    ),
+                  ),
+                  child: Padding(padding: const EdgeInsets.all(5), child: slip),
+                )
+              : slip,
+        ),
+      ),
+    );
+  }
+
+  Widget _moveHandle(FThemeData theme) {
+    return Semantics(
+      button: true,
+      label: 'Move this note',
+      child: GestureDetector(
+        onPanStart: (_) => widget.onDragStart?.call(),
+        onPanUpdate: (details) => widget.onDrag?.call(details.delta),
+        onPanEnd: (_) => widget.onDragEnd?.call(),
+        onPanCancel: () => widget.onDragEnd?.call(),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              'Move',
+              style: theme.typography.xs.copyWith(
+                color: theme.colors.primary,
+                letterSpacing: 0.6,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _namedAction(
+    FThemeData theme, {
+    required String label,
+    required String spoken,
+    required VoidCallback onTap,
+  }) {
+    return Semantics(
+      button: true,
+      label: spoken,
+      child: GestureDetector(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              label,
+              style: theme.typography.xs.copyWith(
+                color: theme.colors.primary,
+                letterSpacing: 0.6,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/landing/presentation/landing_page.dart
+++ b/lib/features/landing/presentation/landing_page.dart
@@ -23,13 +23,20 @@ class LandingPage extends ConsumerWidget {
               final wide = constraints.maxWidth >= 860;
               final headline = Text(
                 'A quiet studio for thinking in space.',
-                style: theme.typography.xl4.copyWith(fontWeight: FontWeight.w500, height: 1.08, letterSpacing: -0.8),
+                style: theme.typography.xl4.copyWith(
+                  fontWeight: FontWeight.w500,
+                  height: 1.08,
+                  letterSpacing: -0.8,
+                ),
               ).penumbraEnter(context);
               final lede = ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 520),
                 child: Text(
                   "A spatial notebook for thoughts that aren't ready to leave the room. Notes stay encrypted in the browser; you hold the key. The studio is yours alone.",
-                  style: theme.typography.lg.copyWith(color: theme.colors.mutedForeground, height: 1.55),
+                  style: theme.typography.lg.copyWith(
+                    color: theme.colors.mutedForeground,
+                    height: 1.55,
+                  ),
                 ),
               ).penumbraEnter(context, delayMs: 40);
               final actions = Wrap(
@@ -38,7 +45,9 @@ class LandingPage extends ConsumerWidget {
                 children: [
                   FButton(
                     onPress: () async {
-                      final failure = await ref.read(authControllerProvider.notifier).demo();
+                      final failure = await ref
+                          .read(authControllerProvider.notifier)
+                          .demo();
                       if (!context.mounted) return;
                       if (failure == null) {
                         context.go('/boards');
@@ -71,7 +80,10 @@ class LandingPage extends ConsumerWidget {
                   actions,
                 ],
               );
-              final teaser = const _Teaser().penumbraEnter(context, delayMs: 120);
+              final teaser = const _Teaser().penumbraEnter(
+                context,
+                delayMs: 120,
+              );
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -109,14 +121,29 @@ class _Facts extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const items = [
-      (title: 'Private by default', body: 'Board bodies are encrypted in the browser before they touch a server.'),
-      (title: 'Accessible by design', body: 'The canvas has a document order, names, and a high-contrast theme.'),
-      (title: 'Legally operable', body: 'GDPR rights, an SBOM, and an honest “we are not CE-marked” note.'),
+      (
+        title: 'Private by default',
+        body:
+            'Board bodies are encrypted in the browser before they touch a server.',
+      ),
+      (
+        title: 'Accessible by design',
+        body:
+            'The canvas has a document order, names, and a high-contrast theme.',
+      ),
+      (
+        title: 'Legally operable',
+        body:
+            'GDPR rights, an SBOM, and an honest “we are not CE-marked” note.',
+      ),
     ];
     return LayoutBuilder(
       builder: (context, constraints) {
         final columns = constraints.maxWidth >= 800;
-        Widget factAt(int i) => _Fact(title: items[i].title, body: items[i].body).penumbraEnter(context, index: i);
+        Widget factAt(int i) => _Fact(
+          title: items[i].title,
+          body: items[i].body,
+        ).penumbraEnter(context, index: i);
         if (columns) {
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -135,7 +162,10 @@ class _Facts extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             for (var i = 0; i < items.length; i++)
-              Padding(padding: const EdgeInsets.only(bottom: 28), child: factAt(i)),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 28),
+                child: factAt(i),
+              ),
           ],
         );
       },
@@ -155,9 +185,21 @@ class _Fact extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(title, style: theme.typography.lg.copyWith(fontFamily: PenumbraInk.displayFamily, fontWeight: FontWeight.w500)),
+        Text(
+          title,
+          style: theme.typography.lg.copyWith(
+            fontFamily: PenumbraInk.displayFamily,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
         const SizedBox(height: 8),
-        Text(body, style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground, height: 1.5)),
+        Text(
+          body,
+          style: theme.typography.sm.copyWith(
+            color: theme.colors.mutedForeground,
+            height: 1.5,
+          ),
+        ),
       ],
     );
   }
@@ -182,7 +224,8 @@ class _LivingTeaser extends StatefulWidget {
   State<_LivingTeaser> createState() => _LivingTeaserState();
 }
 
-class _LivingTeaserState extends State<_LivingTeaser> with SingleTickerProviderStateMixin {
+class _LivingTeaserState extends State<_LivingTeaser>
+    with SingleTickerProviderStateMixin {
   late final AnimationController _drift = AnimationController(
     vsync: this,
     duration: const Duration(seconds: 8),
@@ -236,8 +279,16 @@ class _TeaserStage extends StatelessWidget {
             painter: _DotGridPainter(color: theme.colors.border),
             child: Stack(
               children: [
-                _PaperCard(left: 28 + shiftA.dx, top: 36 + shiftA.dy, label: 'Private by default.'),
-                _PaperCard(left: 250 + shiftB.dx, top: 64 + shiftB.dy, label: 'Accessible by design.'),
+                _PaperCard(
+                  left: 28 + shiftA.dx,
+                  top: 36 + shiftA.dy,
+                  label: 'Private by default.',
+                ),
+                _PaperCard(
+                  left: 250 + shiftB.dx,
+                  top: 64 + shiftB.dy,
+                  label: 'Accessible by design.',
+                ),
                 _PaperCard(
                   left: 140 + shiftC.dx,
                   top: 168 + shiftC.dy,
@@ -254,7 +305,12 @@ class _TeaserStage extends StatelessWidget {
 }
 
 class _PaperCard extends StatelessWidget {
-  const _PaperCard({required this.left, required this.top, required this.label, this.swatch});
+  const _PaperCard({
+    required this.left,
+    required this.top,
+    required this.label,
+    this.swatch,
+  });
 
   final double left;
   final double top;
@@ -275,7 +331,11 @@ class _PaperCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
             border: Border.all(color: theme.colors.border),
             boxShadow: [
-              BoxShadow(color: theme.colors.foreground.withValues(alpha: 0.06), blurRadius: 18, offset: const Offset(0, 8)),
+              BoxShadow(
+                color: theme.colors.foreground.withValues(alpha: 0.06),
+                blurRadius: 18,
+                offset: const Offset(0, 8),
+              ),
             ],
           ),
           child: Padding(
@@ -283,7 +343,12 @@ class _PaperCard extends StatelessWidget {
             child: swatch == null
                 ? SizedBox(
                     width: 180,
-                    child: Text(label, style: theme.typography.sm.copyWith(fontFamily: PenumbraInk.displayFamily)),
+                    child: Text(
+                      label,
+                      style: theme.typography.sm.copyWith(
+                        fontFamily: PenumbraInk.displayFamily,
+                      ),
+                    ),
                   )
                 : Container(width: 72, height: 72, color: swatch),
           ),
@@ -310,5 +375,6 @@ class _DotGridPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant _DotGridPainter oldDelegate) => oldDelegate.color != color;
+  bool shouldRepaint(covariant _DotGridPainter oldDelegate) =>
+      oldDelegate.color != color;
 }

--- a/lib/features/legal/presentation/legal_catalog.dart
+++ b/lib/features/legal/presentation/legal_catalog.dart
@@ -1,5 +1,9 @@
 class LegalDocument {
-  const LegalDocument({required this.title, required this.slug, required this.body});
+  const LegalDocument({
+    required this.title,
+    required this.slug,
+    required this.body,
+  });
 
   final String title;
   final String slug;
@@ -63,9 +67,9 @@ No commercial register. No VAT. Personal interview project.
     body: '''
 The European Accessibility Act applies from 28 June 2025. We design Penumbra against EN 301 549 v3.2.1 (web chapter = WCAG 2.1 Level AA). A personal notebook is likely outside the Act’s sectoral scope. We still treat the standard as the bar and do not claim full EAA conformance.
 
-Implemented: skip-to-content focuses a main landmark, visible focus rings via Forui, named and persisted appearance (System, Light, Dark, High contrast), true black/white high-contrast, reduced-motion no-ops (WCAG 2.2.3), named canvas cards, a list alternative to the spatial canvas, 48px-class targets on primary actions, Flutter web semantics enabled on startup.
+Implemented: skip-to-content focuses a main landmark, visible focus rings via Forui, named and persisted appearance (System, Light, Dark, High contrast), true black/white high-contrast, reduced-motion no-ops (WCAG 2.2.3), named canvas cards, a list alternative to the spatial canvas, named Edit / Delete / Move / Restrict / Unrestrict controls, 48px-class targets on primary actions, Flutter web semantics enabled on startup.
 
-Known gaps: Flutter web paints to a canvas, so the accessibility tree is an opt-in overlay. Contrast of third-party Forui defaults is AA in high-contrast mode by construction; the zinc theme should be verified on a contrast checker before a formal claim. This statement is dated 5 September 2026.
+Known gaps: Flutter web paints to a canvas, so the accessibility tree is an opt-in overlay. InteractiveViewer is not itself a spatial map in that tree — the Index and the Move handle are the mitigation. Contrast of third-party Forui defaults is AA in high-contrast mode by construction; the zinc theme helper text is darkened relative to the paper ground but is not a formal laboratory measurement. This statement is dated 5 September 2026.
 
 Contact: the controller email on the privacy page.
 ''',

--- a/lib/features/legal/presentation/legal_page.dart
+++ b/lib/features/legal/presentation/legal_page.dart
@@ -42,9 +42,15 @@ class LegalPage extends StatelessWidget {
                             child: Text(
                               item.title,
                               style: theme.typography.sm.copyWith(
-                                color: item.slug == doc.slug ? theme.colors.foreground : theme.colors.mutedForeground,
-                                fontWeight: item.slug == doc.slug ? FontWeight.w600 : FontWeight.w400,
-                                decoration: item.slug == doc.slug ? TextDecoration.underline : TextDecoration.none,
+                                color: item.slug == doc.slug
+                                    ? theme.colors.foreground
+                                    : theme.colors.mutedForeground,
+                                fontWeight: item.slug == doc.slug
+                                    ? FontWeight.w600
+                                    : FontWeight.w400,
+                                decoration: item.slug == doc.slug
+                                    ? TextDecoration.underline
+                                    : TextDecoration.none,
                                 decorationColor: theme.colors.primary,
                               ),
                             ),
@@ -59,9 +65,17 @@ class LegalPage extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(doc.title, style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500)),
+                    Text(
+                      doc.title,
+                      style: theme.typography.xl3.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
                     const SizedBox(height: 20),
-                    Text(doc.body, style: theme.typography.md.copyWith(height: 1.6)),
+                    Text(
+                      doc.body,
+                      style: theme.typography.md.copyWith(height: 1.6),
+                    ),
                   ],
                 ),
               ).penumbraEnter(context, delayMs: 40);

--- a/lib/features/privacy/domain/privacy_models.dart
+++ b/lib/features/privacy/domain/privacy_models.dart
@@ -1,6 +1,6 @@
 import 'package:clock/clock.dart';
 
-enum ConsentKind { necessaryStorage, termsOfUse }
+enum ConsentKind { necessaryStorage, termsOfUse, remoteEcho }
 
 class ConsentEvent {
   const ConsentEvent({
@@ -79,13 +79,16 @@ List<DataCategory> penumbraDataCategories() => const [
     name: 'Consent and security events',
     purpose: 'Demonstrate consent and detect abuse',
     lawfulBasis: 'Legal obligation / contract',
-    retention: '90 days for security logs; consents for the life of the account',
+    retention:
+        '90 days for security logs; consents for the life of the account',
   ),
   DataCategory(
     name: 'Optional echo (Gemini)',
-    purpose: 'A short companion to one summoned slip, never the rest of the board',
+    purpose:
+        'A short companion to one summoned slip, never the rest of the board',
     lawfulBasis: 'Consent (GDPR Art. 6(1)(a)); local fallback if no key',
-    retention: 'Not stored at Google by us; the echo slip is encrypted like any other card',
+    retention:
+        'Not stored at Google by us; the echo slip is encrypted like any other card',
   ),
 ];
 
@@ -97,4 +100,8 @@ ConsentEvent grantNecessary({required String id, required String userId}) {
     granted: true,
     at: clock.now().toUtc(),
   );
+}
+
+bool hasGrantedConsent(List<ConsentEvent> events, ConsentKind kind) {
+  return events.any((event) => event.kind == kind && event.granted);
 }

--- a/lib/features/privacy/domain/privacy_repository.dart
+++ b/lib/features/privacy/domain/privacy_repository.dart
@@ -4,7 +4,10 @@ import 'privacy_models.dart';
 
 abstract class PrivacyRepository {
   Future<Result<List<ConsentEvent>, AppFailure>> consents();
-  Future<Result<ConsentEvent, AppFailure>> recordConsent(ConsentKind kind, {required bool granted});
+  Future<Result<ConsentEvent, AppFailure>> recordConsent(
+    ConsentKind kind, {
+    required bool granted,
+  });
   Future<Result<PrivacyExport, AppFailure>> exportMine();
   Future<Result<void, AppFailure>> eraseAccount({String? password});
 }

--- a/lib/features/privacy/presentation/privacy_page.dart
+++ b/lib/features/privacy/presentation/privacy_page.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/providers.dart';
 import '../../../app/theme.dart';
 import '../../../core/a11y/motion.dart';
 import '../../../shared/widgets/chrome.dart';
+import '../../auth/domain/auth_models.dart';
 import '../domain/privacy_models.dart';
 
 class PrivacyPage extends ConsumerStatefulWidget {
@@ -22,6 +24,13 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
   String? _status;
   String? _error;
   PrivacyExport? _export;
+  final _password = TextEditingController();
+
+  @override
+  void dispose() {
+    _password.dispose();
+    super.dispose();
+  }
 
   Future<void> _exportData() async {
     final result = await ref.read(privacyRepositoryProvider).exportMine();
@@ -38,9 +47,24 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
   }
 
   Future<void> _erase() async {
-    final result = await ref.read(privacyRepositoryProvider).eraseAccount();
+    final user = ref.read(authControllerProvider).value;
+    final needsPassword = user?.methods.contains(AuthMethod.password) ?? false;
+    if (needsPassword && _password.text.length < 12) {
+      setState(() => _error = 'Re-enter your password to erase this account.');
+      return;
+    }
+    final result = await ref
+        .read(privacyRepositoryProvider)
+        .eraseAccount(password: needsPassword ? _password.text : null);
+    if (!mounted) return;
     result.when(
-      ok: (_) => setState(() => _status = 'Account erased.'),
+      ok: (_) {
+        setState(() {
+          _status = 'Account erased.';
+          _error = null;
+        });
+        context.go('/');
+      },
       err: (failure) => setState(() => _error = failure.message),
     );
   }
@@ -49,6 +73,8 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
   Widget build(BuildContext context) {
     final theme = context.theme;
     final config = ref.watch(configProvider);
+    final user = ref.watch(authControllerProvider).value;
+    final needsPassword = user?.methods.contains(AuthMethod.password) ?? false;
     return PenumbraChrome(
       title: 'Privacy',
       child: PenumbraPage(
@@ -58,29 +84,67 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Your rights', style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500)).penumbraEnter(context),
+              Text(
+                'Your rights',
+                style: theme.typography.xl3.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ).penumbraEnter(context),
               const SizedBox(height: 10),
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 66 * 8),
                 child: Text(
                   'Controller: ${config.controllerName}. Contact: ${config.controllerEmail}. '
                   'Age: 16+. Necessary storage only — no marketing cookies.',
-                  style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground, height: 1.5),
+                  style: theme.typography.sm.copyWith(
+                    color: theme.colors.mutedForeground,
+                    height: 1.5,
+                  ),
                 ),
               ).penumbraEnter(context, delayMs: 40),
               const SizedBox(height: 28),
-              if (_error != null) FAlert(variant: FAlertVariant.destructive, title: Text(_error!)),
+              if (_error != null)
+                FAlert(
+                  variant: FAlertVariant.destructive,
+                  title: Text(_error!),
+                ),
               if (_status != null) FAlert(title: Text(_status!)),
               const SizedBox(height: 8),
               for (var i = 0; i < penumbraDataCategories().length; i++) ...[
-                _Category(category: penumbraDataCategories()[i]).penumbraEnter(context, index: i),
+                _Category(
+                  category: penumbraDataCategories()[i],
+                ).penumbraEnter(context, index: i),
                 const SizedBox(height: 24),
+              ],
+              if (needsPassword) ...[
+                FTextField(
+                  label: const Text('Password to erase'),
+                  obscureText: true,
+                  description: const Text(
+                    'Art. 17 erasure requires a recent password confirmation.',
+                  ),
+                  control: FTextFieldControl.managed(controller: _password),
+                ),
+                const SizedBox(height: 16),
+              ] else ...[
+                Text(
+                  'OAuth and passkey accounts can erase only with a sign-in from the last five minutes. '
+                  'Sign in again first if that window has closed.',
+                  style: theme.typography.sm.copyWith(
+                    color: theme.colors.mutedForeground,
+                    height: 1.45,
+                  ),
+                ),
+                const SizedBox(height: 16),
               ],
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  FButton(onPress: _exportData, child: const Text('Export my data')),
+                  FButton(
+                    onPress: _exportData,
+                    child: const Text('Export my data'),
+                  ),
                   FButton(
                     variant: FButtonVariant.destructive,
                     onPress: _erase,
@@ -93,8 +157,11 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
                 FButton(
                   variant: FButtonVariant.outline,
                   onPress: () async {
-                    await Clipboard.setData(ClipboardData(text: jsonEncode(_export!.toJson())));
-                    if (context.mounted) announce(context, 'Export copied to clipboard');
+                    await Clipboard.setData(
+                      ClipboardData(text: jsonEncode(_export!.toJson())),
+                    );
+                    if (context.mounted)
+                      announce(context, 'Export copied to clipboard');
                   },
                   child: const Text('Copy JSON'),
                 ),
@@ -127,14 +194,22 @@ class _Category extends StatelessWidget {
         children: [
           Text(
             category.name,
-            style: theme.typography.lg.copyWith(fontFamily: PenumbraInk.displayFamily, fontWeight: FontWeight.w500),
+            style: theme.typography.lg.copyWith(
+              fontFamily: PenumbraInk.displayFamily,
+              fontWeight: FontWeight.w500,
+            ),
           ),
           const SizedBox(height: 6),
-          Text(category.purpose, style: theme.typography.md.copyWith(height: 1.5)),
+          Text(
+            category.purpose,
+            style: theme.typography.md.copyWith(height: 1.5),
+          ),
           const SizedBox(height: 4),
           Text(
             '${category.lawfulBasis} · ${category.retention}',
-            style: theme.typography.xs.copyWith(color: theme.colors.mutedForeground),
+            style: theme.typography.xs.copyWith(
+              color: theme.colors.mutedForeground,
+            ),
           ),
         ],
       ),

--- a/lib/features/story/data/story_catalog.dart
+++ b/lib/features/story/data/story_catalog.dart
@@ -1,5 +1,10 @@
 class StoryChapter {
-  const StoryChapter({required this.id, required this.title, required this.control, required this.body});
+  const StoryChapter({
+    required this.id,
+    required this.title,
+    required this.control,
+    required this.body,
+  });
 
   final String id;
   final String title;
@@ -36,9 +41,9 @@ We did not pull Google Fonts at runtime. Forui already ships Inter. Display type
       title: 'Auth',
       control: 'eIDAS 2 / GDPR Art. 32',
       body: '''
-Five methods: passkeys, Google, GitHub, magic link, password. Passkeys are first in the layout because they are phishing-resistant. Passwords are last and must be twelve characters. OAuth providers are independent controllers for their own identity data.
+Five methods: passkeys, Google, GitHub, magic link, password. Passkeys are first in the layout because they are phishing-resistant. On the cloud path they are real WebAuthn against Supabase Auth; the in-memory studio still fakes a passkey session so reviewers need no authenticator. Passwords are last and must be twelve characters. OAuth providers are independent controllers for their own identity data.
 
-OAuth users do not have a password to derive a wrapping key. They get a twelve-word recovery phrase once. That tradeoff is the honest part of the encryption story.
+OAuth users do not have a password to derive a wrapping key. They get a twelve-word recovery phrase once. That tradeoff is the honest part of the encryption story. WebAuthn PRF wrapping is still future work.
 ''',
     ),
     StoryChapter(
@@ -46,9 +51,9 @@ OAuth users do not have a password to derive a wrapping key. They get a twelve-w
       title: 'Canvas and crypto',
       control: 'GDPR Art. 32 / NIS2 crypto policy',
       body: '''
-Cards are widgets, not paint, so they exist in the semantics tree. A list beside the canvas is the screen-reader order. Arrow keys move the focused card.
+Cards are widgets, not paint, so they exist in the semantics tree. A list beside the canvas is the screen-reader order. Arrow keys or a named Move handle reposition the focused card. Human slips can be edited and deleted; deleting a parent also removes its echo.
 
-Payloads are AES-256-GCM. Tests assert the stored form does not contain plaintext, and that another user cannot read a board (the RLS contract).
+Payloads are AES-256-GCM. Tests assert the stored form does not contain plaintext, and that another user cannot read a board (the RLS contract). Restricted boards refuse writes, including delete (Art. 18).
 ''',
     ),
     StoryChapter(
@@ -101,6 +106,20 @@ The in-memory studio is still how tests and reviewers enter. When both Supabase 
 The European Accessibility Act applies from 28 June 2025. A personal notebook is likely outside its sectors. We still treat EN 301 549 as the bar — named themes that persist, high-contrast that is actually black and white, a canvas you can read without the spatial view.
 
 Development lives on GitHub Issues and a Project Kanban. The agent moves issues as this chat proceeds. That board is not a feature inside the studio.
+''',
+    ),
+    StoryChapter(
+      id: '09',
+      title: 'The four-week deepening',
+      control: 'Roadmap / GitHub Issues',
+      body: '''
+The studio already had a ritual. Four weeks deepened it rather than adding chrome.
+
+Place is reversible: edit, delete (with cascade), and a Move handle that yields the sheet pan while dragging. Recovery phrases can be acknowledged. Boards expose rename, delete, and Art. 18 restrict in the list the legal copy already promised. Remote echoes persist Art. 6(1)(a) consent. Erasure asks for the password the studio always required.
+
+Cloud passkeys call Supabase Auth WebAuthn plus the browser ceremony. The in-memory studio still fakes passkey, Google, GitHub, and magic link so CI never needs secrets. The DEK wrap for passkeys remains the twelve-word phrase; WebAuthn PRF is still future work.
+
+The plan is `docs/roadmap.md`. Issues #6–#13 are the board. This chapter is the retrospective, not a promise of work still undone.
 ''',
     ),
   ];

--- a/lib/features/story/presentation/making_of_page.dart
+++ b/lib/features/story/presentation/making_of_page.dart
@@ -23,19 +23,27 @@ class MakingOfPage extends StatelessWidget {
             children: [
               Text(
                 'Making of Penumbra',
-                style: theme.typography.xl3.copyWith(fontWeight: FontWeight.w500),
+                style: theme.typography.xl3.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
               ).penumbraEnter(context),
               const SizedBox(height: 12),
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 66 * 8),
                 child: Text(
                   'The development story is a product surface. Each chapter names the European control it answers.',
-                  style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground, height: 1.5),
+                  style: theme.typography.sm.copyWith(
+                    color: theme.colors.mutedForeground,
+                    height: 1.5,
+                  ),
                 ),
               ).penumbraEnter(context, delayMs: 40),
               const SizedBox(height: 40),
               for (var i = 0; i < StoryCatalog.chapters.length; i++) ...[
-                _Chapter(chapter: StoryCatalog.chapters[i], index: i).penumbraEnter(context, index: i),
+                _Chapter(
+                  chapter: StoryCatalog.chapters[i],
+                  index: i,
+                ).penumbraEnter(context, index: i),
                 const SizedBox(height: 36),
               ],
             ],
@@ -69,9 +77,20 @@ class _Chapter extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          Text(chapter.title, style: theme.typography.xl2.copyWith(fontFamily: PenumbraInk.displayFamily, fontWeight: FontWeight.w500)),
+          Text(
+            chapter.title,
+            style: theme.typography.xl2.copyWith(
+              fontFamily: PenumbraInk.displayFamily,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
           const SizedBox(height: 4),
-          Text(chapter.control, style: theme.typography.xs.copyWith(color: theme.colors.mutedForeground)),
+          Text(
+            chapter.control,
+            style: theme.typography.xs.copyWith(
+              color: theme.colors.mutedForeground,
+            ),
+          ),
           const SizedBox(height: 12),
           Text(chapter.body, style: theme.typography.md.copyWith(height: 1.6)),
         ],

--- a/lib/features/studio/in_memory_studio.dart
+++ b/lib/features/studio/in_memory_studio.dart
@@ -99,7 +99,8 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
 
   List<String> get wordlist => _wordlist;
 
-  String? debugCipherStorage(String nodeId) => _nodes[nodeId]?.ciphertext.toStorage();
+  String? debugCipherStorage(String nodeId) =>
+      _nodes[nodeId]?.ciphertext.toStorage();
 
   @override
   String? get pendingRecoveryPhrase {
@@ -129,7 +130,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
   }) async {
     final normalized = email.trim().toLowerCase();
     if (!_validEmail(normalized) || password.length < 12) {
-      securityLog.record(type: SecurityEventType.signInFailure, detail: 'password');
+      securityLog.record(
+        type: SecurityEventType.signInFailure,
+        detail: 'password',
+      );
       return const Err(InvalidCredentialsFailure());
     }
     if (_isRateLimited()) {
@@ -140,7 +144,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     final account = id == null ? null : _accounts[id];
     if (account == null || account.passwordHash != _hash(password)) {
       _passwordFailures[normalized] = (_passwordFailures[normalized] ?? 0) + 1;
-      securityLog.record(type: SecurityEventType.signInFailure, detail: 'password');
+      securityLog.record(
+        type: SecurityEventType.signInFailure,
+        detail: 'password',
+      );
       return const Err(InvalidCredentialsFailure());
     }
     if ((_passwordFailures[normalized] ?? 0) >= 8) {
@@ -151,7 +158,11 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     account.lastReauthAt = clock.now().toUtc();
     final user = _toUser(account);
     _setCurrent(user);
-    securityLog.record(type: SecurityEventType.signInSuccess, userId: user.id, detail: 'password');
+    securityLog.record(
+      type: SecurityEventType.signInSuccess,
+      userId: user.id,
+      detail: 'password',
+    );
     return Ok(user);
   }
 
@@ -168,7 +179,9 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
       return const Err(WeakSecretFailure());
     }
     if (_emailIndex.containsKey(normalized)) {
-      return const Err(InvalidCredentialsFailure('An account already exists for that email.'));
+      return const Err(
+        InvalidCredentialsFailure('An account already exists for that email.'),
+      );
     }
     final account = await _createAccount(
       email: normalized,
@@ -181,12 +194,18 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     final user = _toUser(account);
     _setCurrent(user);
     await recordConsent(ConsentKind.necessaryStorage, granted: true);
-    securityLog.record(type: SecurityEventType.signInSuccess, userId: user.id, detail: 'password-signup');
+    securityLog.record(
+      type: SecurityEventType.signInSuccess,
+      userId: user.id,
+      detail: 'password-signup',
+    );
     return Ok(user);
   }
 
   @override
-  Future<Result<void, AuthFailure>> sendMagicLink({required String email}) async {
+  Future<Result<void, AuthFailure>> sendMagicLink({
+    required String email,
+  }) async {
     final normalized = email.trim().toLowerCase();
     if (!_validEmail(normalized)) {
       return const Err(InvalidCredentialsFailure('Enter a valid email.'));
@@ -201,26 +220,37 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
         : _accounts[existingId]!;
     account.methods.add(AuthMethod.magicLink);
     _sessionDek = account.dek;
-    final user = _toUser(account, reveal: account.pendingRecoveryPhrase != null);
+    final user = _toUser(
+      account,
+      reveal: account.pendingRecoveryPhrase != null,
+    );
     _setCurrent(user);
     await recordConsent(ConsentKind.necessaryStorage, granted: true);
-    securityLog.record(type: SecurityEventType.signInSuccess, userId: user.id, detail: 'magic-link');
+    securityLog.record(
+      type: SecurityEventType.signInSuccess,
+      userId: user.id,
+      detail: 'magic-link',
+    );
     return const Ok(null);
   }
 
   @override
-  Future<Result<AuthUser, AuthFailure>> signInWithGoogle() => _federated(AuthMethod.google, 'google-ada@penumbra.studio');
+  Future<Result<AuthUser, AuthFailure>> signInWithGoogle() =>
+      _federated(AuthMethod.google, 'google-ada@penumbra.studio');
 
   @override
-  Future<Result<AuthUser, AuthFailure>> signInWithGitHub() => _federated(AuthMethod.github, 'github-ada@penumbra.studio');
+  Future<Result<AuthUser, AuthFailure>> signInWithGitHub() =>
+      _federated(AuthMethod.github, 'github-ada@penumbra.studio');
 
   @override
-  Future<Result<AuthUser, AuthFailure>> signInWithPasskey() => _federated(AuthMethod.passkey, 'passkey-ada@penumbra.studio');
+  Future<Result<AuthUser, AuthFailure>> signInWithPasskey() =>
+      _federated(AuthMethod.passkey, 'passkey-ada@penumbra.studio');
 
   @override
   Future<Result<void, AuthFailure>> registerPasskey() async {
     final user = _current;
-    if (user == null) return const Err(AuthUnavailableFailure('Sign in first.'));
+    if (user == null)
+      return const Err(AuthUnavailableFailure('Sign in first.'));
     _accounts[user.id]?.methods.add(AuthMethod.passkey);
     _setCurrent(_toUser(_accounts[user.id]!));
     return const Ok(null);
@@ -249,7 +279,9 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     _setCurrent(user);
     await recordConsent(ConsentKind.necessaryStorage, granted: true);
     await create(title: 'Quiet thoughts');
-    final boards = (_current == null) ? <Board>[] : _boards.values.where((b) => b.ownerId == _current!.id).toList();
+    final boards = (_current == null)
+        ? <Board>[]
+        : _boards.values.where((b) => b.ownerId == _current!.id).toList();
     if (boards.isNotEmpty) {
       final boardId = boards.first.id;
       await upsert(
@@ -283,7 +315,11 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
         ),
       );
     }
-    securityLog.record(type: SecurityEventType.signInSuccess, userId: user.id, detail: 'demo');
+    securityLog.record(
+      type: SecurityEventType.signInSuccess,
+      userId: user.id,
+      detail: 'demo',
+    );
     return Ok(user);
   }
 
@@ -317,10 +353,16 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     if (user == null) return const Err(AuthUnavailableFailure());
     final account = _accounts[user.id]!;
     final reauth = account.lastReauthAt;
-    if (reauth == null || clock.now().toUtc().difference(reauth) > const Duration(minutes: 5)) {
-      return const Err(AuthUnavailableFailure('Re-authenticate to erase this account.'));
+    if (reauth == null ||
+        clock.now().toUtc().difference(reauth) > const Duration(minutes: 5)) {
+      return const Err(
+        AuthUnavailableFailure('Re-authenticate to erase this account.'),
+      );
     }
-    securityLog.record(type: SecurityEventType.accountErasureRequested, userId: user.id);
+    securityLog.record(
+      type: SecurityEventType.accountErasureRequested,
+      userId: user.id,
+    );
     _boards.removeWhere((_, board) => board.ownerId == user.id);
     _nodes.removeWhere((_, node) => node.ownerId == user.id);
     _consents.remove(user.id);
@@ -329,7 +371,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     _current = null;
     _sessionDek = null;
     _controller.add(null);
-    securityLog.record(type: SecurityEventType.accountErasureCompleted, userId: user.id);
+    securityLog.record(
+      type: SecurityEventType.accountErasureCompleted,
+      userId: user.id,
+    );
     return const Ok(null);
   }
 
@@ -346,7 +391,8 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     if (user == null) return const Err(UnauthenticatedFailure());
     final board = _boards[id];
     if (board == null) return const Err(NotFoundFailure('Board not found.'));
-    if (board.ownerId != user.id) return const Err(ForbiddenFailure('That board belongs to someone else.'));
+    if (board.ownerId != user.id)
+      return const Err(ForbiddenFailure('That board belongs to someone else.'));
     return Ok(board);
   }
 
@@ -354,20 +400,33 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     final user = _requireUser();
     if (user == null) return const Err(UnauthenticatedFailure());
     final trimmed = title.trim();
-    if (trimmed.isEmpty) return const Err(ValidationFailure('Give the board a name.'));
-    final board = Board.create(id: _uuid.v4(), ownerId: user.id, title: trimmed);
+    if (trimmed.isEmpty)
+      return const Err(ValidationFailure('Give the board a name.'));
+    final board = Board.create(
+      id: _uuid.v4(),
+      ownerId: user.id,
+      title: trimmed,
+    );
     _boards[board.id] = board;
     return Ok(board);
   }
 
-  Future<Result<Board, AppFailure>> rename({required String id, required String title}) async {
+  Future<Result<Board, AppFailure>> rename({
+    required String id,
+    required String title,
+  }) async {
     final result = await getById(id);
     return result.when(
       ok: (board) {
         if (board.restricted) {
-          return const Err(ForbiddenFailure('This board is restricted (Art. 18).'));
+          return const Err(
+            ForbiddenFailure('This board is restricted (Art. 18).'),
+          );
         }
-        final updated = board.copyWith(title: title.trim(), updatedAt: clock.now().toUtc());
+        final updated = board.copyWith(
+          title: title.trim(),
+          updatedAt: clock.now().toUtc(),
+        );
         _boards[id] = updated;
         return Ok(updated);
       },
@@ -387,11 +446,17 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     );
   }
 
-  Future<Result<Board, AppFailure>> setRestricted({required String id, required bool restricted}) async {
+  Future<Result<Board, AppFailure>> setRestricted({
+    required String id,
+    required bool restricted,
+  }) async {
     final result = await getById(id);
     return result.when(
       ok: (board) {
-        final updated = board.copyWith(restricted: restricted, updatedAt: clock.now().toUtc());
+        final updated = board.copyWith(
+          restricted: restricted,
+          updatedAt: clock.now().toUtc(),
+        );
         _boards[id] = updated;
         securityLog.record(
           type: SecurityEventType.boardRestricted,
@@ -413,7 +478,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
       case Ok():
         final out = <BoardNode>[];
         for (final stored in _nodes.values.where((n) => n.boardId == boardId)) {
-          switch (await _cipher.decrypt(dekBytes: dek, ciphertext: stored.ciphertext)) {
+          switch (await _cipher.decrypt(
+            dekBytes: dek,
+            ciphertext: stored.ciphertext,
+          )) {
             case Err():
               continue;
             case Ok(:final value):
@@ -442,9 +510,15 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
       case Ok(:final value):
         final board = value;
         if (board.restricted) {
-          return const Err(ForbiddenFailure('This board is restricted (Art. 18).'));
+          return const Err(
+            ForbiddenFailure('This board is restricted (Art. 18).'),
+          );
         }
-        final siblings = await _decryptedSiblings(boardId: node.boardId, dek: dek, exceptId: node.id);
+        final siblings = await _decryptedSiblings(
+          boardId: node.boardId,
+          dek: dek,
+          exceptId: node.id,
+        );
         switch (EchoPairing.validateWrite(node, siblings)) {
           case Err(:final failure):
             return Err(failure);
@@ -477,10 +551,20 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     switch (board) {
       case Err(:final failure):
         return Err(failure);
-      case Ok():
+      case Ok(:final value):
+        if (value.restricted) {
+          return const Err(
+            ForbiddenFailure('This board is restricted (Art. 18).'),
+          );
+        }
         final cascade = <String>{nodeId};
-        for (final other in _nodes.values.where((n) => n.boardId == stored.boardId && n.id != nodeId)) {
-          switch (await _cipher.decrypt(dekBytes: dek, ciphertext: other.ciphertext)) {
+        for (final other in _nodes.values.where(
+          (n) => n.boardId == stored.boardId && n.id != nodeId,
+        )) {
+          switch (await _cipher.decrypt(
+            dekBytes: dek,
+            ciphertext: other.ciphertext,
+          )) {
             case Err():
               continue;
             case Ok(:final value):
@@ -503,8 +587,13 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     required String exceptId,
   }) async {
     final out = <BoardNode>[];
-    for (final stored in _nodes.values.where((n) => n.boardId == boardId && n.id != exceptId)) {
-      switch (await _cipher.decrypt(dekBytes: dek, ciphertext: stored.ciphertext)) {
+    for (final stored in _nodes.values.where(
+      (n) => n.boardId == boardId && n.id != exceptId,
+    )) {
+      switch (await _cipher.decrypt(
+        dekBytes: dek,
+        ciphertext: stored.ciphertext,
+      )) {
         case Err():
           continue;
         case Ok(:final value):
@@ -530,7 +619,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
   }
 
   @override
-  Future<Result<ConsentEvent, AppFailure>> recordConsent(ConsentKind kind, {required bool granted}) async {
+  Future<Result<ConsentEvent, AppFailure>> recordConsent(
+    ConsentKind kind, {
+    required bool granted,
+  }) async {
     final user = _requireUser();
     if (user == null) return const Err(UnauthenticatedFailure());
     final event = ConsentEvent(
@@ -548,7 +640,10 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
   Future<Result<PrivacyExport, AppFailure>> exportMine() async {
     final user = _requireUser();
     if (user == null) return const Err(UnauthenticatedFailure());
-    securityLog.record(type: SecurityEventType.exportRequested, userId: user.id);
+    securityLog.record(
+      type: SecurityEventType.exportRequested,
+      userId: user.id,
+    );
     final boards = _boards.values.where((b) => b.ownerId == user.id).toList();
     final nodes = <Map<String, Object?>>[];
     for (final board in boards) {
@@ -608,25 +703,42 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     return reauth.when(
       ok: (_) async {
         final deleted = await deleteAccount();
-        return deleted.when(ok: (_) => const Ok(null), err: (f) => Err(UnavailableFailure(f.message)));
+        return deleted.when(
+          ok: (_) => const Ok(null),
+          err: (f) => Err(UnavailableFailure(f.message)),
+        );
       },
       err: (f) async => Err(UnauthenticatedFailure(f.message)),
     );
   }
 
-  Future<Result<AuthUser, AuthFailure>> _federated(AuthMethod method, String email) async {
+  Future<Result<AuthUser, AuthFailure>> _federated(
+    AuthMethod method,
+    String email,
+  ) async {
     final existing = _emailIndex[email];
     final isNew = existing == null;
     final account = existing == null
-        ? await _createAccount(email: email, methods: {method}, wrappingSecret: null)
+        ? await _createAccount(
+            email: email,
+            methods: {method},
+            wrappingSecret: null,
+          )
         : _accounts[existing]!;
     account.methods.add(method);
     _sessionDek = account.dek;
     account.lastReauthAt = clock.now().toUtc();
-    final user = _toUser(account, reveal: isNew || account.pendingRecoveryPhrase != null);
+    final user = _toUser(
+      account,
+      reveal: isNew || account.pendingRecoveryPhrase != null,
+    );
     _setCurrent(user);
     await recordConsent(ConsentKind.necessaryStorage, granted: true);
-    securityLog.record(type: SecurityEventType.signInSuccess, userId: user.id, detail: method.name);
+    securityLog.record(
+      type: SecurityEventType.signInSuccess,
+      userId: user.id,
+      detail: method.name,
+    );
     return Ok(user);
   }
 
@@ -637,25 +749,38 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
     String? passwordHash,
     String? displayName,
   }) async {
-    final dek = Uint8List.fromList(List<int>.generate(32, (_) => _random.nextInt(256)));
-    final salt = Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
+    final dek = Uint8List.fromList(
+      List<int>.generate(32, (_) => _random.nextInt(256)),
+    );
+    final salt = Uint8List.fromList(
+      List<int>.generate(16, (_) => _random.nextInt(256)),
+    );
     String secret = wrappingSecret ?? '';
     String? phrase;
     if (secret.isEmpty) {
-      final entropy = Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
-      final generated = RecoveryPhrase.fromEntropy(entropy: entropy, wordlist: _wordlist).when(
-        ok: (p) => p.display,
-        err: (_) => base64Url.encode(entropy),
+      final entropy = Uint8List.fromList(
+        List<int>.generate(16, (_) => _random.nextInt(256)),
       );
+      final generated = RecoveryPhrase.fromEntropy(
+        entropy: entropy,
+        wordlist: _wordlist,
+      ).when(ok: (p) => p.display, err: (_) => base64Url.encode(entropy));
       phrase = generated;
       secret = generated;
     }
-    final wrapping = await _derivation.deriveWrappingKey(secret: secret, salt: salt);
+    final wrapping = await _derivation.deriveWrappingKey(
+      secret: secret,
+      salt: salt,
+    );
     final wrapKey = wrapping.when(ok: (bytes) => bytes, err: (_) => dek);
     final wrapped = await _cipher.encrypt(dekBytes: wrapKey, plaintext: dek);
     final wrappedCipher = wrapped.when(
       ok: (c) => c,
-      err: (_) => Ciphertext(nonce: Uint8List(12), cipherBytes: dek, mac: Uint8List(16)),
+      err: (_) => Ciphertext(
+        nonce: Uint8List(12),
+        cipherBytes: dek,
+        mac: Uint8List(16),
+      ),
     );
     final account = _Account(
       id: _uuid.v4(),
@@ -679,7 +804,8 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
       email: account.email,
       displayName: account.displayName,
       methods: {...account.methods},
-      needsRecoveryPhraseReveal: reveal && account.pendingRecoveryPhrase != null,
+      needsRecoveryPhraseReveal:
+          reveal && account.pendingRecoveryPhrase != null,
     );
   }
 
@@ -690,12 +816,14 @@ class InMemoryStudio implements AuthRepository, PrivacyRepository {
 
   AuthUser? _requireUser() => _current;
 
-  bool _validEmail(String email) => RegExp(r'^[^@]+@[^@]+\.[^@]+$').hasMatch(email);
+  bool _validEmail(String email) =>
+      RegExp(r'^[^@]+@[^@]+\.[^@]+$').hasMatch(email);
 
   bool _isRateLimited() {
     final last = _lastPasswordAttempt;
     if (last == null) return false;
-    return clock.now().difference(last) < const Duration(milliseconds: 20) && _passwordFailures.length > 20;
+    return clock.now().difference(last) < const Duration(milliseconds: 20) &&
+        _passwordFailures.length > 20;
   }
 
   String _hash(String password) {

--- a/lib/features/studio/studio_repositories.dart
+++ b/lib/features/studio/studio_repositories.dart
@@ -17,18 +17,23 @@ class InMemoryBoardRepository implements BoardRepository {
   Future<Result<Board, AppFailure>> getById(String id) => studio.getById(id);
 
   @override
-  Future<Result<Board, AppFailure>> create({required String title}) => studio.create(title: title);
+  Future<Result<Board, AppFailure>> create({required String title}) =>
+      studio.create(title: title);
 
   @override
-  Future<Result<Board, AppFailure>> rename({required String id, required String title}) =>
-      studio.rename(id: id, title: title);
+  Future<Result<Board, AppFailure>> rename({
+    required String id,
+    required String title,
+  }) => studio.rename(id: id, title: title);
 
   @override
   Future<Result<void, AppFailure>> delete(String id) => studio.delete(id);
 
   @override
-  Future<Result<Board, AppFailure>> setRestricted({required String id, required bool restricted}) =>
-      studio.setRestricted(id: id, restricted: restricted);
+  Future<Result<Board, AppFailure>> setRestricted({
+    required String id,
+    required bool restricted,
+  }) => studio.setRestricted(id: id, restricted: restricted);
 }
 
 class InMemoryCanvasRepository implements CanvasRepository {
@@ -36,13 +41,16 @@ class InMemoryCanvasRepository implements CanvasRepository {
   final InMemoryStudio studio;
 
   @override
-  Future<Result<List<BoardNode>, AppFailure>> listNodes(String boardId) => studio.listNodes(boardId);
+  Future<Result<List<BoardNode>, AppFailure>> listNodes(String boardId) =>
+      studio.listNodes(boardId);
 
   @override
-  Future<Result<BoardNode, AppFailure>> upsert(BoardNode node) => studio.upsert(node);
+  Future<Result<BoardNode, AppFailure>> upsert(BoardNode node) =>
+      studio.upsert(node);
 
   @override
-  Future<Result<void, AppFailure>> delete(String nodeId) => studio.deleteNode(nodeId);
+  Future<Result<void, AppFailure>> delete(String nodeId) =>
+      studio.deleteNode(nodeId);
 }
 
 class SupabaseBoardRepository implements BoardRepository {
@@ -56,18 +64,23 @@ class SupabaseBoardRepository implements BoardRepository {
   Future<Result<Board, AppFailure>> getById(String id) => studio.getById(id);
 
   @override
-  Future<Result<Board, AppFailure>> create({required String title}) => studio.create(title: title);
+  Future<Result<Board, AppFailure>> create({required String title}) =>
+      studio.create(title: title);
 
   @override
-  Future<Result<Board, AppFailure>> rename({required String id, required String title}) =>
-      studio.rename(id: id, title: title);
+  Future<Result<Board, AppFailure>> rename({
+    required String id,
+    required String title,
+  }) => studio.rename(id: id, title: title);
 
   @override
   Future<Result<void, AppFailure>> delete(String id) => studio.delete(id);
 
   @override
-  Future<Result<Board, AppFailure>> setRestricted({required String id, required bool restricted}) =>
-      studio.setRestricted(id: id, restricted: restricted);
+  Future<Result<Board, AppFailure>> setRestricted({
+    required String id,
+    required bool restricted,
+  }) => studio.setRestricted(id: id, restricted: restricted);
 }
 
 class SupabaseCanvasRepository implements CanvasRepository {
@@ -75,11 +88,14 @@ class SupabaseCanvasRepository implements CanvasRepository {
   final SupabaseStudio studio;
 
   @override
-  Future<Result<List<BoardNode>, AppFailure>> listNodes(String boardId) => studio.listNodes(boardId);
+  Future<Result<List<BoardNode>, AppFailure>> listNodes(String boardId) =>
+      studio.listNodes(boardId);
 
   @override
-  Future<Result<BoardNode, AppFailure>> upsert(BoardNode node) => studio.upsert(node);
+  Future<Result<BoardNode, AppFailure>> upsert(BoardNode node) =>
+      studio.upsert(node);
 
   @override
-  Future<Result<void, AppFailure>> delete(String nodeId) => studio.deleteNode(nodeId);
+  Future<Result<void, AppFailure>> delete(String nodeId) =>
+      studio.deleteNode(nodeId);
 }

--- a/lib/features/studio/supabase_studio.dart
+++ b/lib/features/studio/supabase_studio.dart
@@ -1,3 +1,6 @@
+// GoTrue passkeys are @experimental in 2.27; that is the shipped cloud API.
+// ignore_for_file: experimental_member_use
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
@@ -11,7 +14,9 @@ import '../../core/crypto/recovery_phrase.dart';
 import '../../core/errors.dart';
 import '../../core/logging/security_log.dart';
 import '../../core/result.dart';
+import '../auth/data/passkey_ceremony_factory.dart';
 import '../auth/domain/auth_models.dart';
+import '../auth/domain/passkey_ceremony.dart';
 import '../boards/domain/board.dart';
 import '../boards/domain/echo_pairing.dart';
 import '../privacy/domain/privacy_models.dart';
@@ -29,13 +34,15 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     KeyDerivation? derivation,
     Random? random,
     String? redirectTo,
+    PasskeyCeremony? passkeys,
   }) : _client = client,
        _wordlist = wordlist,
        _store = store,
        _cipher = cipher ?? PayloadCipher(),
        _derivation = derivation ?? KeyDerivation(),
        _random = random ?? Random.secure(),
-       _redirectTo = redirectTo {
+       _redirectTo = redirectTo,
+       _passkeys = passkeys ?? createPasskeyCeremony() {
     _authSub = _client.auth.onAuthStateChange.listen((data) {
       if (_holdListener) return;
       unawaited(_onSession(data.session, wrappingSecret: null));
@@ -50,6 +57,7 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   final KeyDerivation _derivation;
   final Random _random;
   final String? _redirectTo;
+  final PasskeyCeremony _passkeys;
 
   final _controller = StreamController<AuthUser?>.broadcast();
   StreamSubscription<AuthState>? _authSub;
@@ -65,7 +73,8 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   AuthUser? get current => _current;
 
   @override
-  String? get pendingRecoveryPhrase => _current == null ? null : _pendingRecoveryPhrase;
+  String? get pendingRecoveryPhrase =>
+      _current == null ? null : _pendingRecoveryPhrase;
 
   @override
   Stream<AuthUser?> watch() async* {
@@ -92,7 +101,10 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     }
     _holdListener = true;
     try {
-      final response = await _client.auth.signInWithPassword(email: normalized, password: password);
+      final response = await _client.auth.signInWithPassword(
+        email: normalized,
+        password: password,
+      );
       final session = response.session;
       if (session == null) {
         return const Err(InvalidCredentialsFailure());
@@ -102,7 +114,11 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
       if (user == null || _sessionDek == null) {
         return const Err(InvalidCredentialsFailure());
       }
-      await _audit(SecurityEventType.signInSuccess, userId: user.id, detail: 'password');
+      await _audit(
+        SecurityEventType.signInSuccess,
+        userId: user.id,
+        detail: 'password',
+      );
       return Ok(user);
     } on AuthException catch (error) {
       return Err(_mapAuth(error));
@@ -133,16 +149,24 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
       final session = response.session;
       if (session == null) {
         return const Err(
-          AuthUnavailableFailure('Confirm your email, then sign in to enter the studio.'),
+          AuthUnavailableFailure(
+            'Confirm your email, then sign in to enter the studio.',
+          ),
         );
       }
       await _onSession(session, wrappingSecret: password, markReauth: true);
       final user = _current;
       if (user == null) {
-        return const Err(AuthUnavailableFailure('Sign-up did not establish a session.'));
+        return const Err(
+          AuthUnavailableFailure('Sign-up did not establish a session.'),
+        );
       }
       await recordConsent(ConsentKind.necessaryStorage, granted: true);
-      await _audit(SecurityEventType.signInSuccess, userId: user.id, detail: 'password-signup');
+      await _audit(
+        SecurityEventType.signInSuccess,
+        userId: user.id,
+        detail: 'password-signup',
+      );
       return Ok(user);
     } on AuthWeakPasswordException catch (error) {
       return Err(WeakSecretFailure(error.message));
@@ -154,13 +178,18 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   }
 
   @override
-  Future<Result<void, AuthFailure>> sendMagicLink({required String email}) async {
+  Future<Result<void, AuthFailure>> sendMagicLink({
+    required String email,
+  }) async {
     final normalized = email.trim().toLowerCase();
     if (!_validEmail(normalized)) {
       return const Err(InvalidCredentialsFailure('Enter a valid email.'));
     }
     try {
-      await _client.auth.signInWithOtp(email: normalized, emailRedirectTo: _redirectTo);
+      await _client.auth.signInWithOtp(
+        email: normalized,
+        emailRedirectTo: _redirectTo,
+      );
       return const Ok(null);
     } on AuthException catch (error) {
       return Err(_mapAuth(error));
@@ -168,25 +197,79 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   }
 
   @override
-  Future<Result<AuthUser, AuthFailure>> signInWithGoogle() => _federated(OAuthProvider.google);
+  Future<Result<AuthUser, AuthFailure>> signInWithGoogle() =>
+      _federated(OAuthProvider.google);
 
   @override
-  Future<Result<AuthUser, AuthFailure>> signInWithGitHub() => _federated(OAuthProvider.github);
+  Future<Result<AuthUser, AuthFailure>> signInWithGitHub() =>
+      _federated(OAuthProvider.github);
 
   @override
   Future<Result<AuthUser, AuthFailure>> signInWithPasskey() async {
-    return const Err(
-      AuthUnavailableFailure(
-        'Passkeys are not available on this Supabase project yet. Use Google, GitHub, a magic link, or a password.',
-      ),
-    );
+    if (!_passkeys.isSupported) {
+      return Err(passkeyUnavailable(supported: false));
+    }
+    _holdListener = true;
+    try {
+      final challenge = await _client.auth.passkey.startAuthentication();
+      final credential = await _passkeys.get(challenge.options);
+      final response = await _client.auth.passkey.verifyAuthentication(
+        challengeId: challenge.challengeId,
+        credential: credential,
+      );
+      final session = response.session;
+      if (session == null) {
+        return Err(passkeyUnavailable(supported: true));
+      }
+      await _onSession(session, wrappingSecret: null, markReauth: true);
+      final user = _current;
+      if (user == null || _sessionDek == null) {
+        return const Err(
+          AuthUnavailableFailure(
+            'Passkey sign-in did not unlock the studio key.',
+          ),
+        );
+      }
+      await _audit(
+        SecurityEventType.signInSuccess,
+        userId: user.id,
+        detail: 'passkey',
+      );
+      return Ok(user);
+    } on PasskeyCancelled {
+      return const Err(AuthCancelledFailure());
+    } on UnsupportedError {
+      return Err(passkeyUnavailable(supported: false));
+    } on AuthException catch (error) {
+      return Err(_mapAuth(error));
+    } finally {
+      _holdListener = false;
+    }
   }
 
   @override
   Future<Result<void, AuthFailure>> registerPasskey() async {
-    return const Err(
-      AuthUnavailableFailure('Passkey registration is not available on this Supabase project yet.'),
-    );
+    if (!_passkeys.isSupported) {
+      return Err(passkeyUnavailable(supported: false));
+    }
+    if (_current == null) {
+      return const Err(AuthUnavailableFailure('Sign in first.'));
+    }
+    try {
+      final challenge = await _client.auth.passkey.startRegistration();
+      final credential = await _passkeys.create(challenge.options);
+      await _client.auth.passkey.verifyRegistration(
+        challengeId: challenge.challengeId,
+        credential: credential,
+      );
+      return const Ok(null);
+    } on PasskeyCancelled {
+      return const Err(AuthCancelledFailure());
+    } on UnsupportedError {
+      return Err(passkeyUnavailable(supported: false));
+    } on AuthException catch (error) {
+      return Err(_mapAuth(error));
+    }
   }
 
   @override
@@ -225,8 +308,11 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
       return const Err(InvalidCredentialsFailure());
     } else {
       final last = _lastReauthAt;
-      if (last == null || clock.now().toUtc().difference(last) > const Duration(minutes: 5)) {
-        return const Err(AuthUnavailableFailure('Sign in again to erase this account.'));
+      if (last == null ||
+          clock.now().toUtc().difference(last) > const Duration(minutes: 5)) {
+        return const Err(
+          AuthUnavailableFailure('Sign in again to erase this account.'),
+        );
       }
       return const Ok(null);
     }
@@ -239,8 +325,11 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (user == null) return const Err(AuthUnavailableFailure());
     final reauth = _lastReauthAt;
-    if (reauth == null || clock.now().toUtc().difference(reauth) > const Duration(minutes: 5)) {
-      return const Err(AuthUnavailableFailure('Re-authenticate to erase this account.'));
+    if (reauth == null ||
+        clock.now().toUtc().difference(reauth) > const Duration(minutes: 5)) {
+      return const Err(
+        AuthUnavailableFailure('Re-authenticate to erase this account.'),
+      );
     }
     await _audit(SecurityEventType.accountErasureRequested, userId: user.id);
     try {
@@ -265,8 +354,14 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (user == null) return const Err(UnauthenticatedFailure());
     try {
-      final rows = await _client.from('boards').select().eq('owner_id', user.id).order('updated_at', ascending: false);
-      return Ok([for (final row in rows as List) _boardFrom(row as Map<String, dynamic>)]);
+      final rows = await _client
+          .from('boards')
+          .select()
+          .eq('owner_id', user.id)
+          .order('updated_at', ascending: false);
+      return Ok([
+        for (final row in rows as List) _boardFrom(row as Map<String, dynamic>),
+      ]);
     } on Object catch (error) {
       return Err(_mapPostgrest(error));
     }
@@ -276,11 +371,17 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (user == null) return const Err(UnauthenticatedFailure());
     try {
-      final row = await _client.from('boards').select().eq('id', id).maybeSingle();
+      final row = await _client
+          .from('boards')
+          .select()
+          .eq('id', id)
+          .maybeSingle();
       if (row == null) return const Err(NotFoundFailure('Board not found.'));
       final board = _boardFrom(row);
       if (board.ownerId != user.id) {
-        return const Err(ForbiddenFailure('That board belongs to someone else.'));
+        return const Err(
+          ForbiddenFailure('That board belongs to someone else.'),
+        );
       }
       return Ok(board);
     } on Object catch (error) {
@@ -292,30 +393,42 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (user == null) return const Err(UnauthenticatedFailure());
     final trimmed = title.trim();
-    if (trimmed.isEmpty) return const Err(ValidationFailure('Give the board a name.'));
+    if (trimmed.isEmpty)
+      return const Err(ValidationFailure('Give the board a name.'));
     try {
-      final row = await _client.from('boards').insert({
-        'owner_id': user.id,
-        'title': trimmed,
-      }).select().single();
+      final row = await _client
+          .from('boards')
+          .insert({'owner_id': user.id, 'title': trimmed})
+          .select()
+          .single();
       return Ok(_boardFrom(row));
     } on Object catch (error) {
       return Err(_mapPostgrest(error));
     }
   }
 
-  Future<Result<Board, AppFailure>> rename({required String id, required String title}) async {
+  Future<Result<Board, AppFailure>> rename({
+    required String id,
+    required String title,
+  }) async {
     final existing = await getById(id);
     return existing.when(
       ok: (board) async {
         if (board.restricted) {
-          return const Err(ForbiddenFailure('This board is restricted (Art. 18).'));
+          return const Err(
+            ForbiddenFailure('This board is restricted (Art. 18).'),
+          );
         }
         try {
-          final row = await _client.from('boards').update({
-            'title': title.trim(),
-            'updated_at': clock.now().toUtc().toIso8601String(),
-          }).eq('id', id).select().single();
+          final row = await _client
+              .from('boards')
+              .update({
+                'title': title.trim(),
+                'updated_at': clock.now().toUtc().toIso8601String(),
+              })
+              .eq('id', id)
+              .select()
+              .single();
           return Ok(_boardFrom(row));
         } on Object catch (error) {
           return Err(_mapPostgrest(error));
@@ -340,15 +453,23 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     );
   }
 
-  Future<Result<Board, AppFailure>> setRestricted({required String id, required bool restricted}) async {
+  Future<Result<Board, AppFailure>> setRestricted({
+    required String id,
+    required bool restricted,
+  }) async {
     final existing = await getById(id);
     return existing.when(
       ok: (board) async {
         try {
-          final row = await _client.from('boards').update({
-            'restricted': restricted,
-            'updated_at': clock.now().toUtc().toIso8601String(),
-          }).eq('id', id).select().single();
+          final row = await _client
+              .from('boards')
+              .update({
+                'restricted': restricted,
+                'updated_at': clock.now().toUtc().toIso8601String(),
+              })
+              .eq('id', id)
+              .select()
+              .single();
           await _audit(
             SecurityEventType.boardRestricted,
             userId: board.ownerId,
@@ -371,16 +492,24 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
         return Err(failure);
       case Ok():
         try {
-          final rows = await _client.from('board_nodes').select().eq('board_id', boardId);
+          final rows = await _client
+              .from('board_nodes')
+              .select()
+              .eq('board_id', boardId);
           final out = <BoardNode>[];
           for (final row in rows as List) {
             final map = row as Map<String, dynamic>;
-            final stored = Ciphertext.fromStorage(map['ciphertext'] as String? ?? '');
+            final stored = Ciphertext.fromStorage(
+              map['ciphertext'] as String? ?? '',
+            );
             switch (stored) {
               case Err():
                 continue;
               case Ok(:final value):
-                switch (await _cipher.decrypt(dekBytes: dek, ciphertext: value)) {
+                switch (await _cipher.decrypt(
+                  dekBytes: dek,
+                  ciphertext: value,
+                )) {
                   case Err():
                     continue;
                   case Ok(:final value):
@@ -390,7 +519,9 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
                       BoardNode.fromPayload(
                         id: map['id'] as String,
                         boardId: boardId,
-                        payload: decoded.map((k, v) => MapEntry(k.toString(), v)),
+                        payload: decoded.map(
+                          (k, v) => MapEntry(k.toString(), v),
+                        ),
                       ),
                     );
                 }
@@ -413,9 +544,15 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
       case Ok(:final value):
         final board = value;
         if (board.restricted) {
-          return const Err(ForbiddenFailure('This board is restricted (Art. 18).'));
+          return const Err(
+            ForbiddenFailure('This board is restricted (Art. 18).'),
+          );
         }
-        final siblings = await _decryptedSiblings(boardId: node.boardId, dek: dek, exceptId: node.id);
+        final siblings = await _decryptedSiblings(
+          boardId: node.boardId,
+          dek: dek,
+          exceptId: node.id,
+        );
         switch (EchoPairing.validateWrite(node, siblings)) {
           case Err(:final failure):
             return Err(failure);
@@ -434,9 +571,10 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
                 'owner_id': user.id,
                 'ciphertext': value.toStorage(),
               });
-              await _client.from('boards').update({
-                'updated_at': clock.now().toUtc().toIso8601String(),
-              }).eq('id', board.id);
+              await _client
+                  .from('boards')
+                  .update({'updated_at': clock.now().toUtc().toIso8601String()})
+                  .eq('id', board.id);
               return Ok(node);
             } on Object catch (error) {
               return Err(_mapPostgrest(error));
@@ -450,25 +588,42 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (dek == null || user == null) return const Err(UnauthenticatedFailure());
     try {
-      final row = await _client.from('board_nodes').select().eq('id', nodeId).maybeSingle();
+      final row = await _client
+          .from('board_nodes')
+          .select()
+          .eq('id', nodeId)
+          .maybeSingle();
       if (row == null) return const Err(NotFoundFailure('Card not found.'));
       final boardId = row['board_id'] as String;
       switch (await getById(boardId)) {
         case Err(:final failure):
           return Err(failure);
-        case Ok():
+        case Ok(:final value):
+          if (value.restricted) {
+            return const Err(
+              ForbiddenFailure('This board is restricted (Art. 18).'),
+            );
+          }
           final cascade = <String>{nodeId};
-          final siblings = await _client.from('board_nodes').select().eq('board_id', boardId);
+          final siblings = await _client
+              .from('board_nodes')
+              .select()
+              .eq('board_id', boardId);
           for (final other in siblings as List) {
             final map = other as Map<String, dynamic>;
             final id = map['id'] as String;
             if (id == nodeId) continue;
-            final stored = Ciphertext.fromStorage(map['ciphertext'] as String? ?? '');
+            final stored = Ciphertext.fromStorage(
+              map['ciphertext'] as String? ?? '',
+            );
             switch (stored) {
               case Err():
                 continue;
               case Ok(:final value):
-                switch (await _cipher.decrypt(dekBytes: dek, ciphertext: value)) {
+                switch (await _cipher.decrypt(
+                  dekBytes: dek,
+                  ciphertext: value,
+                )) {
                   case Err():
                     continue;
                   case Ok(:final value):
@@ -494,7 +649,11 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     final user = _current;
     if (user == null) return const Err(UnauthenticatedFailure());
     try {
-      final rows = await _client.from('consent_events').select().eq('user_id', user.id).order('at');
+      final rows = await _client
+          .from('consent_events')
+          .select()
+          .eq('user_id', user.id)
+          .order('at');
       return Ok([
         for (final row in rows as List)
           ConsentEvent(
@@ -511,15 +670,18 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   }
 
   @override
-  Future<Result<ConsentEvent, AppFailure>> recordConsent(ConsentKind kind, {required bool granted}) async {
+  Future<Result<ConsentEvent, AppFailure>> recordConsent(
+    ConsentKind kind, {
+    required bool granted,
+  }) async {
     final user = _current;
     if (user == null) return const Err(UnauthenticatedFailure());
     try {
-      final row = await _client.from('consent_events').insert({
-        'user_id': user.id,
-        'kind': kind.name,
-        'granted': granted,
-      }).select().single();
+      final row = await _client
+          .from('consent_events')
+          .insert({'user_id': user.id, 'kind': kind.name, 'granted': granted})
+          .select()
+          .single();
       return Ok(
         ConsentEvent(
           id: row['id'] as String,
@@ -562,7 +724,8 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
             err: (_) {},
           );
         }
-        final consentRows = (await consents()).okOrNull ?? const <ConsentEvent>[];
+        final consentRows =
+            (await consents()).okOrNull ?? const <ConsentEvent>[];
         return Ok(
           PrivacyExport(
             generatedAt: clock.now().toUtc(),
@@ -604,22 +767,34 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     return reauth.when(
       ok: (_) async {
         final deleted = await deleteAccount();
-        return deleted.when(ok: (_) => const Ok(null), err: (f) => Err(UnavailableFailure(f.message)));
+        return deleted.when(
+          ok: (_) => const Ok(null),
+          err: (f) => Err(UnavailableFailure(f.message)),
+        );
       },
       err: (f) async => Err(UnauthenticatedFailure(f.message)),
     );
   }
 
-  Future<Result<AuthUser, AuthFailure>> _federated(OAuthProvider provider) async {
+  Future<Result<AuthUser, AuthFailure>> _federated(
+    OAuthProvider provider,
+  ) async {
     try {
-      final launched = await _client.auth.signInWithOAuth(provider, redirectTo: _redirectTo);
+      final launched = await _client.auth.signInWithOAuth(
+        provider,
+        redirectTo: _redirectTo,
+      );
       if (!launched) return const Err(AuthCancelledFailure());
       final user = _current;
       if (user != null) return Ok(user);
       return Ok(
         AuthUser(
           id: 'oauth-redirect',
-          methods: {provider == OAuthProvider.google ? AuthMethod.google : AuthMethod.github},
+          methods: {
+            provider == OAuthProvider.google
+                ? AuthMethod.google
+                : AuthMethod.github,
+          },
         ),
       );
     } on AuthException catch (error) {
@@ -627,30 +802,48 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     }
   }
 
-  Future<void> _onSession(Session? session, {String? wrappingSecret, bool markReauth = false}) {
+  Future<void> _onSession(
+    Session? session, {
+    String? wrappingSecret,
+    bool markReauth = false,
+  }) {
     final previous = _hydrateGate;
     final next = () async {
       await previous;
-      await _hydrate(session, wrappingSecret: wrappingSecret, markReauth: markReauth);
+      await _hydrate(
+        session,
+        wrappingSecret: wrappingSecret,
+        markReauth: markReauth,
+      );
     }();
     _hydrateGate = next;
     return next;
   }
 
-  Future<void> _hydrate(Session? session, {String? wrappingSecret, bool markReauth = false}) async {
+  Future<void> _hydrate(
+    Session? session, {
+    String? wrappingSecret,
+    bool markReauth = false,
+  }) async {
     if (session == null) {
       _clearLocal();
       return;
     }
     final remote = session.user;
-    if (_sessionDek != null && _current?.id == remote.id && wrappingSecret == null) {
+    if (_sessionDek != null &&
+        _current?.id == remote.id &&
+        wrappingSecret == null) {
       if (markReauth) _lastReauthAt = clock.now().toUtc();
       return;
     }
 
     Map<String, dynamic>? profile;
     try {
-      profile = await _client.from('profiles').select().eq('id', remote.id).maybeSingle();
+      profile = await _client
+          .from('profiles')
+          .select()
+          .eq('id', remote.id)
+          .maybeSingle();
     } on Object {
       profile = null;
     }
@@ -662,21 +855,35 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     var firstWrap = false;
 
     if (wrappingSecret != null && saltRaw != null && wrappedRaw != null) {
-      dek = await _unwrapDek(secret: wrappingSecret, saltRaw: saltRaw, wrappedRaw: wrappedRaw);
+      dek = await _unwrapDek(
+        secret: wrappingSecret,
+        saltRaw: saltRaw,
+        wrappedRaw: wrappedRaw,
+      );
     }
 
     dek ??= await _unlockDevice(remote.id);
 
-    if (dek == null && wrappingSecret != null && (saltRaw == null || wrappedRaw == null)) {
+    if (dek == null &&
+        wrappingSecret != null &&
+        (saltRaw == null || wrappedRaw == null)) {
       dek = _newDek();
-      firstWrap = await _persistWrap(userId: remote.id, dek: dek, secret: wrappingSecret);
+      firstWrap = await _persistWrap(
+        userId: remote.id,
+        dek: dek,
+        secret: wrappingSecret,
+      );
       if (!firstWrap) dek = null;
     }
 
     if (dek == null && (saltRaw == null || wrappedRaw == null)) {
       final phrase = _newPhrase();
       dek = _newDek();
-      firstWrap = await _persistWrap(userId: remote.id, dek: dek, secret: phrase);
+      firstWrap = await _persistWrap(
+        userId: remote.id,
+        dek: dek,
+        secret: phrase,
+      );
       if (firstWrap) {
         _pendingRecoveryPhrase = phrase;
         reveal = true;
@@ -713,12 +920,18 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
   }) async {
     final salt = _decodeB64(saltRaw);
     if (salt == null) return null;
-    final wrapping = await _derivation.deriveWrappingKey(secret: secret, salt: salt);
+    final wrapping = await _derivation.deriveWrappingKey(
+      secret: secret,
+      salt: salt,
+    );
     final wrapKey = wrapping.okOrNull;
     if (wrapKey == null) return null;
     final stored = Ciphertext.fromStorage(wrappedRaw).okOrNull;
     if (stored == null) return null;
-    return (await _cipher.decrypt(dekBytes: wrapKey, ciphertext: stored)).okOrNull;
+    return (await _cipher.decrypt(
+      dekBytes: wrapKey,
+      ciphertext: stored,
+    )).okOrNull;
   }
 
   Future<bool> _persistWrap({
@@ -726,11 +939,19 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     required Uint8List dek,
     required String secret,
   }) async {
-    final salt = Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
-    final wrapping = await _derivation.deriveWrappingKey(secret: secret, salt: salt);
+    final salt = Uint8List.fromList(
+      List<int>.generate(16, (_) => _random.nextInt(256)),
+    );
+    final wrapping = await _derivation.deriveWrappingKey(
+      secret: secret,
+      salt: salt,
+    );
     final wrapKey = wrapping.okOrNull;
     if (wrapKey == null) return false;
-    final wrapped = (await _cipher.encrypt(dekBytes: wrapKey, plaintext: dek)).okOrNull;
+    final wrapped = (await _cipher.encrypt(
+      dekBytes: wrapKey,
+      plaintext: dek,
+    )).okOrNull;
     if (wrapped == null) return false;
     try {
       await _client.from('profiles').upsert({
@@ -757,9 +978,15 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
 
   Future<void> _rememberDevice(String userId, Uint8List dek) async {
     final key = _newDek();
-    final wrapped = (await _cipher.encrypt(dekBytes: key, plaintext: dek)).okOrNull;
+    final wrapped = (await _cipher.encrypt(
+      dekBytes: key,
+      plaintext: dek,
+    )).okOrNull;
     if (wrapped == null) return;
-    await _store.write(_deviceKey(userId), base64Url.encode(key).replaceAll('=', ''));
+    await _store.write(
+      _deviceKey(userId),
+      base64Url.encode(key).replaceAll('=', ''),
+    );
     await _store.write(_deviceWrapped(userId), wrapped.toStorage());
   }
 
@@ -775,7 +1002,11 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     ];
   }
 
-  Future<void> _audit(SecurityEventType type, {String? userId, String? detail}) async {
+  Future<void> _audit(
+    SecurityEventType type, {
+    String? userId,
+    String? detail,
+  }) async {
     if (userId == null) return;
     try {
       await _client.from('security_events').insert({
@@ -792,7 +1023,9 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     return AuthUser(
       id: user.id,
       email: user.email,
-      displayName: user.userMetadata?['full_name'] as String? ?? user.userMetadata?['name'] as String?,
+      displayName:
+          user.userMetadata?['full_name'] as String? ??
+          user.userMetadata?['name'] as String?,
       methods: _methods(user),
       needsRecoveryPhraseReveal: reveal && _pendingRecoveryPhrase != null,
     );
@@ -847,11 +1080,17 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     _controller.add(null);
   }
 
-  Uint8List _newDek() => Uint8List.fromList(List<int>.generate(32, (_) => _random.nextInt(256)));
+  Uint8List _newDek() =>
+      Uint8List.fromList(List<int>.generate(32, (_) => _random.nextInt(256)));
 
   String _newPhrase() {
-    final entropy = Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
-    return RecoveryPhrase.fromEntropy(entropy: entropy, wordlist: _wordlist).when(
+    final entropy = Uint8List.fromList(
+      List<int>.generate(16, (_) => _random.nextInt(256)),
+    );
+    return RecoveryPhrase.fromEntropy(
+      entropy: entropy,
+      wordlist: _wordlist,
+    ).when(
       ok: (phrase) => phrase.display,
       err: (_) => base64Url.encode(entropy),
     );
@@ -868,7 +1107,18 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
 
   AuthFailure _mapAuth(AuthException error) {
     if (error.statusCode == '429') return const RateLimitedFailure();
-    if (error is AuthWeakPasswordException) return WeakSecretFailure(error.message);
+    if (error is AuthWeakPasswordException)
+      return WeakSecretFailure(error.message);
+    final code = error.code;
+    if (code == 'passkey_disabled' || code == 'webauthn_credential_not_found') {
+      return const AuthUnavailableFailure(kPasskeyProjectDisabledMessage);
+    }
+    if (code == 'webauthn_challenge_expired' ||
+        code == 'webauthn_verification_failed') {
+      return const AuthCancelledFailure(
+        'That passkey could not be verified. Try again.',
+      );
+    }
     return InvalidCredentialsFailure(error.message);
   }
 
@@ -885,7 +1135,8 @@ class SupabaseStudio implements AuthRepository, PrivacyRepository {
     return const UnavailableFailure('The studio could not reach the cloud.');
   }
 
-  bool _validEmail(String email) => RegExp(r'^[^@]+@[^@]+\.[^@]+$').hasMatch(email);
+  bool _validEmail(String email) =>
+      RegExp(r'^[^@]+@[^@]+\.[^@]+$').hasMatch(email);
 
   String _deviceKey(String userId) => 'penumbra.device_key.$userId';
   String _deviceWrapped(String userId) => 'penumbra.device_wrapped.$userId';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,10 +29,14 @@ Future<void> main() async {
   final config = PenumbraConfig.fromEnvironment();
   final prefs = await SharedPreferences.getInstance();
   final deviceStore = PrefsDeviceStore(prefs);
-  final savedAppearance = appearanceFromName(deviceStore.read(AppearanceController.storageKey));
+  final savedAppearance = appearanceFromName(
+    deviceStore.read(AppearanceController.storageKey),
+  );
   var echoPrompt = kPenumbraEchoSystemPrompt;
   try {
-    echoPrompt = await rootBundle.loadString('assets/prompts/penumbra_echo.txt');
+    echoPrompt = await rootBundle.loadString(
+      'assets/prompts/penumbra_echo.txt',
+    );
   } catch (_) {
     // Asset missing in a stripped test bind — keep the in-code fallback.
   }
@@ -41,15 +45,23 @@ Future<void> main() async {
     configProvider.overrideWithValue(config),
     echoPromptProvider.overrideWithValue(echoPrompt),
     appearanceProvider.overrideWith(
-      (ref) => AppearanceController(store: deviceStore, initial: savedAppearance),
+      (ref) =>
+          AppearanceController(store: deviceStore, initial: savedAppearance),
     ),
   ];
 
   switch (config.studioMode) {
     case StudioMode.memory:
-      overrides.add(studioProvider.overrideWithValue(InMemoryStudio(wordlist: wordlist.words)));
+      overrides.add(
+        studioProvider.overrideWithValue(
+          InMemoryStudio(wordlist: wordlist.words),
+        ),
+      );
     case StudioMode.supabase:
-      await Supabase.initialize(url: config.supabaseUrl, publishableKey: config.supabaseAnonKey);
+      await Supabase.initialize(
+        url: config.supabaseUrl,
+        publishableKey: config.supabaseAnonKey,
+      );
       final remote = SupabaseStudio(
         client: Supabase.instance.client,
         wordlist: wordlist.words,
@@ -58,16 +70,15 @@ Future<void> main() async {
       );
       overrides.addAll([
         authRepositoryProvider.overrideWithValue(remote),
-        boardRepositoryProvider.overrideWithValue(SupabaseBoardRepository(remote)),
-        canvasRepositoryProvider.overrideWithValue(SupabaseCanvasRepository(remote)),
+        boardRepositoryProvider.overrideWithValue(
+          SupabaseBoardRepository(remote),
+        ),
+        canvasRepositoryProvider.overrideWithValue(
+          SupabaseCanvasRepository(remote),
+        ),
         privacyRepositoryProvider.overrideWithValue(remote),
       ]);
   }
 
-  runApp(
-    ProviderScope(
-      overrides: overrides,
-      child: const PenumbraApp(),
-    ),
-  );
+  runApp(ProviderScope(overrides: overrides, child: const PenumbraApp()));
 }

--- a/lib/shared/widgets/chrome.dart
+++ b/lib/shared/widgets/chrome.dart
@@ -31,7 +31,9 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
     final theme = context.theme;
     final user = ref.watch(authControllerProvider).value;
     final appearance = ref.watch(appearanceProvider);
-    final punctum = appearance == PenumbraAppearance.highContrast ? theme.colors.foreground : PenumbraInk.copper;
+    final punctum = appearance == PenumbraAppearance.highContrast
+        ? theme.colors.foreground
+        : PenumbraInk.copper;
 
     return Stack(
       children: [
@@ -48,7 +50,10 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                 final compact = width < 900;
                 final tiny = width < 640;
                 return Padding(
-                  padding: EdgeInsets.symmetric(horizontal: tiny ? 12 : 24, vertical: tiny ? 12 : 16),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: tiny ? 12 : 24,
+                    vertical: tiny ? 12 : 16,
+                  ),
                   child: Row(
                     children: [
                       _Wordmark(punctum: punctum, compact: tiny),
@@ -58,14 +63,20 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                           child: Text(
                             widget.title!,
                             overflow: TextOverflow.ellipsis,
-                            style: theme.typography.sm.copyWith(color: theme.colors.mutedForeground),
+                            style: theme.typography.sm.copyWith(
+                              color: theme.colors.mutedForeground,
+                            ),
                           ),
                         ),
                       ],
                       const Spacer(),
-                      if (!tiny) const _NavLink(label: 'Making of', path: '/making-of'),
+                      if (!tiny)
+                        const _NavLink(label: 'Making of', path: '/making-of'),
                       if (compact)
-                        _OverflowNav(signedIn: user != null, includeMakingOf: tiny)
+                        _OverflowNav(
+                          signedIn: user != null,
+                          includeMakingOf: tiny,
+                        )
                       else ...[
                         const _NavLink(label: 'Legal', path: '/legal/privacy'),
                         if (user != null) ...[
@@ -78,14 +89,18 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                         tiny
                             ? FButton.icon(
                                 semanticsLabel: 'Sign out',
-                                onPress: () => ref.read(authControllerProvider.notifier).signOut(),
+                                onPress: () => ref
+                                    .read(authControllerProvider.notifier)
+                                    .signOut(),
                                 child: const Icon(FLucideIcons.logOut),
                               )
                             : FButton(
                                 variant: FButtonVariant.ghost,
                                 mainAxisSize: MainAxisSize.min,
                                 semanticsLabel: 'Sign out',
-                                onPress: () => ref.read(authControllerProvider.notifier).signOut(),
+                                onPress: () => ref
+                                    .read(authControllerProvider.notifier)
+                                    .signOut(),
                                 prefix: const Icon(FLucideIcons.logOut),
                                 child: const Text('Sign out'),
                               )
@@ -93,7 +108,9 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                         FButton(
                           variant: FButtonVariant.primary,
                           mainAxisSize: MainAxisSize.min,
-                          size: tiny ? FButtonSizeVariant.sm : FButtonSizeVariant.md,
+                          size: tiny
+                              ? FButtonSizeVariant.sm
+                              : FButtonSizeVariant.md,
                           onPress: () => context.go('/sign-in'),
                           child: const Text('Sign in'),
                         ),
@@ -101,7 +118,9 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                       FButton.icon(
                         semanticsLabel:
                             'Appearance: ${appearance.spokenName}. Switch to ${appearance.next.spokenName}.',
-                        size: tiny ? FButtonSizeVariant.sm : FButtonSizeVariant.md,
+                        size: tiny
+                            ? FButtonSizeVariant.sm
+                            : FButtonSizeVariant.md,
                         onPress: () {
                           final next = appearance.next;
                           ref.read(appearanceProvider.notifier).cycle();
@@ -110,7 +129,8 @@ class _PenumbraChromeState extends ConsumerState<PenumbraChrome> {
                         child: Icon(switch (appearance) {
                           PenumbraAppearance.light => FLucideIcons.sun,
                           PenumbraAppearance.dark => FLucideIcons.moon,
-                          PenumbraAppearance.highContrast => FLucideIcons.contrast,
+                          PenumbraAppearance.highContrast =>
+                            FLucideIcons.contrast,
                           PenumbraAppearance.system => FLucideIcons.sunMoon,
                         }),
                       ),
@@ -172,11 +192,12 @@ class _Wordmark extends StatelessWidget {
           children: [
             Text(
               'Penumbra',
-              style: (compact ? theme.typography.lg : theme.typography.xl).copyWith(
-                fontFamily: PenumbraInk.displayFamily,
-                fontWeight: FontWeight.w500,
-                letterSpacing: -0.3,
-              ),
+              style: (compact ? theme.typography.lg : theme.typography.xl)
+                  .copyWith(
+                    fontFamily: PenumbraInk.displayFamily,
+                    fontWeight: FontWeight.w500,
+                    letterSpacing: -0.3,
+                  ),
             ),
             const SizedBox(width: 8),
             Container(
@@ -203,11 +224,24 @@ class _OverflowNav extends StatelessWidget {
       menu: [
         FItemGroup(
           children: [
-            if (includeMakingOf) FItem(title: const Text('Making of'), onPress: () => context.go('/making-of')),
-            FItem(title: const Text('Legal'), onPress: () => context.go('/legal/privacy')),
+            if (includeMakingOf)
+              FItem(
+                title: const Text('Making of'),
+                onPress: () => context.go('/making-of'),
+              ),
+            FItem(
+              title: const Text('Legal'),
+              onPress: () => context.go('/legal/privacy'),
+            ),
             if (signedIn) ...[
-              FItem(title: const Text('Boards'), onPress: () => context.go('/boards')),
-              FItem(title: const Text('Privacy'), onPress: () => context.go('/privacy')),
+              FItem(
+                title: const Text('Boards'),
+                onPress: () => context.go('/boards'),
+              ),
+              FItem(
+                title: const Text('Privacy'),
+                onPress: () => context.go('/privacy'),
+              ),
             ],
           ],
         ),
@@ -230,7 +264,8 @@ class _NavLink extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final current = GoRouterState.of(context).uri.path;
-    final selected = current == path || (path != '/' && current.startsWith(path));
+    final selected =
+        current == path || (path != '/' && current.startsWith(path));
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 2),
       child: FButton(
@@ -267,5 +302,9 @@ class PenumbraPage extends StatelessWidget {
 }
 
 Future<void> announce(BuildContext context, String message) async {
-  await SemanticsService.sendAnnouncement(View.of(context), message, TextDirection.ltr);
+  await SemanticsService.sendAnnouncement(
+    View.of(context),
+    message,
+    TextDirection.ltr,
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: penumbra
 description: A privacy-first visual thinking studio. Private by default. Visible only to you. Accessible by design.
 publish_to: "none"
-version: 1.0.0+1
+version: 1.1.0+2
 
 environment:
   sdk: ^3.12.1

--- a/test/app/app_widget_test.dart
+++ b/test/app/app_widget_test.dart
@@ -7,13 +7,13 @@ import 'package:penumbra/app/app.dart';
 import 'package:penumbra/app/providers.dart';
 import 'package:penumbra/features/studio/in_memory_studio.dart';
 
-InMemoryStudio studio() =>
-    InMemoryStudio(wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync());
+InMemoryStudio studio() => InMemoryStudio(
+  wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+);
 
 Future<void> pumpApp(WidgetTester tester, InMemoryStudio s) async {
-  tester.platformDispatcher.accessibilityFeaturesTestValue = const FakeAccessibilityFeatures(
-    disableAnimations: true,
-  );
+  tester.platformDispatcher.accessibilityFeaturesTestValue =
+      const FakeAccessibilityFeatures(disableAnimations: true);
   addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
   await tester.pumpWidget(
     ProviderScope(
@@ -50,22 +50,25 @@ void main() {
     expect(find.text('Quiet thoughts'), findsWidgets);
   });
 
-  testWidgets('sign-in offers passkey, Google, GitHub, password and magic link', (tester) async {
-    await pumpApp(tester, studio());
-    await tester.tap(find.text('Sign in').first);
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 400));
-    expect(find.text('Continue with a passkey'), findsOneWidget);
-    expect(find.text('Continue with Google'), findsOneWidget);
-    expect(find.text('Continue with GitHub'), findsOneWidget);
-    expect(find.text('Email me a magic link'), findsOneWidget);
-    await tester.ensureVisible(find.text('Use a password instead'));
-    await tester.tap(find.text('Use a password instead'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-    await tester.ensureVisible(find.text('Sign in with password'));
-    expect(find.text('Sign in with password'), findsOneWidget);
-  });
+  testWidgets(
+    'sign-in offers passkey, Google, GitHub, password and magic link',
+    (tester) async {
+      await pumpApp(tester, studio());
+      await tester.tap(find.text('Sign in').first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.text('Continue with a passkey'), findsOneWidget);
+      expect(find.text('Continue with Google'), findsOneWidget);
+      expect(find.text('Continue with GitHub'), findsOneWidget);
+      expect(find.text('Email me a magic link'), findsOneWidget);
+      await tester.ensureVisible(find.text('Use a password instead'));
+      await tester.tap(find.text('Use a password instead'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.ensureVisible(find.text('Sign in with password'));
+      expect(find.text('Sign in with password'), findsOneWidget);
+    },
+  );
 
   testWidgets('reduced motion uses a static teaser', (tester) async {
     await pumpApp(tester, studio());
@@ -76,8 +79,13 @@ void main() {
     expect(tester.binding.transientCallbackCount, start);
   });
 
-  testWidgets('appearance control names the current and next theme', (tester) async {
+  testWidgets('appearance control names the current and next theme', (
+    tester,
+  ) async {
     await pumpApp(tester, studio());
-    expect(find.bySemanticsLabel('Appearance: System. Switch to Light.'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('Appearance: System. Switch to Light.'),
+      findsOneWidget,
+    );
   });
 }

--- a/test/app/appearance_test.dart
+++ b/test/app/appearance_test.dart
@@ -18,7 +18,10 @@ void main() {
     final controller = AppearanceController(store: store);
     controller.cycle();
     await Future<void>.delayed(Duration.zero);
-    expect(store.read(AppearanceController.storageKey), PenumbraAppearance.light.name);
+    expect(
+      store.read(AppearanceController.storageKey),
+      PenumbraAppearance.light.name,
+    );
     controller.set(PenumbraAppearance.highContrast);
     await Future<void>.delayed(Duration.zero);
     expect(store.read(AppearanceController.storageKey), 'highContrast');

--- a/test/core/config_test.dart
+++ b/test/core/config_test.dart
@@ -3,20 +3,32 @@ import 'package:penumbra/core/config.dart';
 
 void main() {
   test('neither env var uses the in-memory studio', () {
-    expect(resolveStudioMode(supabaseUrl: '', supabaseAnonKey: ''), StudioMode.memory);
-    expect(resolveStudioMode(supabaseUrl: '  ', supabaseAnonKey: ''), StudioMode.memory);
+    expect(
+      resolveStudioMode(supabaseUrl: '', supabaseAnonKey: ''),
+      StudioMode.memory,
+    );
+    expect(
+      resolveStudioMode(supabaseUrl: '  ', supabaseAnonKey: ''),
+      StudioMode.memory,
+    );
   });
 
   test('both env vars select Supabase', () {
     expect(
-      resolveStudioMode(supabaseUrl: 'https://example.supabase.co', supabaseAnonKey: 'anon-key'),
+      resolveStudioMode(
+        supabaseUrl: 'https://example.supabase.co',
+        supabaseAnonKey: 'anon-key',
+      ),
       StudioMode.supabase,
     );
   });
 
   test('half-set config fails closed', () {
     expect(
-      () => resolveStudioMode(supabaseUrl: 'https://example.supabase.co', supabaseAnonKey: ''),
+      () => resolveStudioMode(
+        supabaseUrl: 'https://example.supabase.co',
+        supabaseAnonKey: '',
+      ),
       throwsA(isA<ArgumentError>()),
     );
     expect(

--- a/test/core/crypto_test.dart
+++ b/test/core/crypto_test.dart
@@ -5,7 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:penumbra/core/crypto/payload_cipher.dart';
 import 'package:penumbra/core/crypto/recovery_phrase.dart';
 
-List<String> loadWordlist() => File('assets/crypto/bip39_english.txt').readAsLinesSync();
+List<String> loadWordlist() =>
+    File('assets/crypto/bip39_english.txt').readAsLinesSync();
 
 void main() {
   late List<String> wordlist;
@@ -23,9 +24,15 @@ void main() {
 
   test('AES-GCM round-trips and rejects tampering', () async {
     final dek = List<int>.generate(32, (i) => i + 1);
-    final encrypted = await cipher.encrypt(dekBytes: dek, plaintext: 'quiet thoughts'.codeUnits);
+    final encrypted = await cipher.encrypt(
+      dekBytes: dek,
+      plaintext: 'quiet thoughts'.codeUnits,
+    );
     final cipherText = encrypted.okOrNull!;
-    final decrypted = await cipher.decrypt(dekBytes: dek, ciphertext: cipherText);
+    final decrypted = await cipher.decrypt(
+      dekBytes: dek,
+      ciphertext: cipherText,
+    );
     expect(String.fromCharCodes(decrypted.okOrNull!), 'quiet thoughts');
 
     final tampered = Ciphertext(
@@ -39,7 +46,10 @@ void main() {
 
   test('ciphertext storage is reversible and contains no plaintext', () async {
     final dek = List<int>.generate(32, (i) => 32 - i);
-    final encrypted = await cipher.encrypt(dekBytes: dek, plaintext: 'secret-card'.codeUnits);
+    final encrypted = await cipher.encrypt(
+      dekBytes: dek,
+      plaintext: 'secret-card'.codeUnits,
+    );
     final stored = encrypted.okOrNull!.toStorage();
     expect(stored.contains('secret-card'), isFalse);
     final parsed = Ciphertext.fromStorage(stored).okOrNull!;
@@ -49,18 +59,31 @@ void main() {
 
   test('recovery phrase encodes 16 bytes with a checksum', () {
     final entropy = Uint8List.fromList(List<int>.generate(16, (i) => i * 3));
-    final phrase = RecoveryPhrase.fromEntropy(entropy: entropy, wordlist: wordlist).okOrNull!;
+    final phrase = RecoveryPhrase.fromEntropy(
+      entropy: entropy,
+      wordlist: wordlist,
+    ).okOrNull!;
     expect(phrase.words, hasLength(12));
-    final parsed = RecoveryPhrase.parse(phrase: phrase.display, wordlist: wordlist);
+    final parsed = RecoveryPhrase.parse(
+      phrase: phrase.display,
+      wordlist: wordlist,
+    );
     expect(parsed.isOk, isTrue);
     expect(parsed.okOrNull!.toEntropy(wordlist).okOrNull, entropy);
   });
 
   test('recovery phrase rejects a flipped word', () {
     final entropy = Uint8List.fromList(List<int>.filled(16, 7));
-    final phrase = RecoveryPhrase.fromEntropy(entropy: entropy, wordlist: wordlist).okOrNull!;
-    final mutated = [...phrase.words]..[0] = phrase.words[0] == 'abandon' ? 'ability' : 'abandon';
-    final parsed = RecoveryPhrase.parse(phrase: mutated.join(' '), wordlist: wordlist);
+    final phrase = RecoveryPhrase.fromEntropy(
+      entropy: entropy,
+      wordlist: wordlist,
+    ).okOrNull!;
+    final mutated = [...phrase.words]
+      ..[0] = phrase.words[0] == 'abandon' ? 'ability' : 'abandon';
+    final parsed = RecoveryPhrase.parse(
+      phrase: mutated.join(' '),
+      wordlist: wordlist,
+    );
     expect(parsed.isErr, isTrue);
   });
 }

--- a/test/features/auth/passkey_unavailable_test.dart
+++ b/test/features/auth/passkey_unavailable_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penumbra/features/auth/domain/auth_models.dart';
+import 'package:penumbra/features/auth/domain/passkey_ceremony.dart';
+
+class _FakeCeremony implements PasskeyCeremony {
+  _FakeCeremony({required this.supported});
+
+  final bool supported;
+
+  @override
+  bool get isSupported => supported;
+
+  @override
+  Future<Map<String, dynamic>> create(
+    Map<String, dynamic> publicKeyOptions,
+  ) async => publicKeyOptions;
+
+  @override
+  Future<Map<String, dynamic>> get(
+    Map<String, dynamic> publicKeyOptions,
+  ) async => publicKeyOptions;
+}
+
+void main() {
+  test(
+    'unsupported browsers get honest copy, never a silent password fallback',
+    () {
+      final failure = passkeyUnavailable(
+        supported: _FakeCeremony(supported: false).isSupported,
+      );
+      expect(failure, isA<AuthUnavailableFailure>());
+      expect(failure.message, contains('cannot create a passkey'));
+      expect(failure.message.toLowerCase(), isNot(contains('falling back')));
+    },
+  );
+
+  test('a disabled Supabase project is named as the operator gap', () {
+    final failure = passkeyUnavailable(supported: true, projectDisabled: true);
+    expect(failure.message, contains('Supabase project'));
+  });
+}

--- a/test/features/boards/board_lifecycle_test.dart
+++ b/test/features/boards/board_lifecycle_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penumbra/app/app.dart';
+import 'package:penumbra/app/providers.dart';
+import 'package:penumbra/features/canvas/domain/echo_composer.dart';
+import 'package:penumbra/features/studio/in_memory_studio.dart';
+
+InMemoryStudio studio() => InMemoryStudio(
+  wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+);
+
+Future<void> pumpStudio(WidgetTester tester, InMemoryStudio s) async {
+  tester.view.physicalSize = const Size(1400, 900);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  tester.platformDispatcher.accessibilityFeaturesTestValue =
+      const FakeAccessibilityFeatures(disableAnimations: true);
+  addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        studioProvider.overrideWithValue(s),
+        echoComposerProvider.overrideWithValue(const LocalEchoComposer()),
+      ],
+      child: const PenumbraApp(),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
+}
+
+void main() {
+  testWidgets('restricting a board makes the canvas read-only', (tester) async {
+    await pumpStudio(tester, studio());
+    await tester.tap(find.text('Enter the studio'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 800));
+    await tester.tap(find.text('Restrict'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 800));
+    expect(find.textContaining('Art. 18'), findsWidgets);
+    expect(find.text('Edit'), findsNothing);
+    expect(find.text('Delete'), findsNothing);
+  });
+}

--- a/test/features/boards/echo_pairing_test.dart
+++ b/test/features/boards/echo_pairing_test.dart
@@ -4,23 +4,23 @@ import 'package:penumbra/features/boards/domain/board.dart';
 import 'package:penumbra/features/boards/domain/echo_pairing.dart';
 
 BoardNode human({required String id, String text = 'A thought'}) => BoardNode(
-      id: id,
-      boardId: 'b',
-      x: 0,
-      y: 0,
-      kind: NodeKind.text,
-      text: text,
-    );
+  id: id,
+  boardId: 'b',
+  x: 0,
+  y: 0,
+  kind: NodeKind.text,
+  text: text,
+);
 
 BoardNode echo({required String id, required String parentId}) => BoardNode(
-      id: id,
-      boardId: 'b',
-      x: 28,
-      y: 36,
-      kind: NodeKind.echo,
-      text: 'Quieter.',
-      parentId: parentId,
-    );
+  id: id,
+  boardId: 'b',
+  x: 28,
+  y: 36,
+  kind: NodeKind.echo,
+  text: 'Quieter.',
+  parentId: parentId,
+);
 
 void main() {
   test('a second echo on the same parent is refused', () {
@@ -38,7 +38,10 @@ void main() {
     final first = echo(id: 'e1', parentId: 'h1');
     expect(EchoPairing.canSummon(parent, [parent, first]), isFalse);
     expect(EchoPairing.canSummon(parent, [parent]), isTrue);
-    expect(EchoPairing.validateWrite(echo(id: 'e2', parentId: 'h1'), [parent]).isOk, isTrue);
+    expect(
+      EchoPairing.validateWrite(echo(id: 'e2', parentId: 'h1'), [parent]).isOk,
+      isTrue,
+    );
   });
 
   test('swatches cannot be echoed', () {
@@ -51,7 +54,9 @@ void main() {
       colorArgb: 0xFF000000,
     );
     expect(EchoPairing.canSummon(swatch, [swatch]), isFalse);
-    final result = EchoPairing.validateWrite(echo(id: 'e1', parentId: 's1'), [swatch]);
+    final result = EchoPairing.validateWrite(echo(id: 'e1', parentId: 's1'), [
+      swatch,
+    ]);
     expect(result.isErr, isTrue);
   });
 

--- a/test/features/boards/node_motion_test.dart
+++ b/test/features/boards/node_motion_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penumbra/features/boards/domain/board.dart';
+import 'package:penumbra/features/boards/domain/node_motion.dart';
+
+void main() {
+  const parent = BoardNode(
+    id: 'p',
+    boardId: 'b',
+    x: 10,
+    y: 20,
+    kind: NodeKind.text,
+    text: 'note',
+  );
+  const echo = BoardNode(
+    id: 'e',
+    boardId: 'b',
+    x: 258,
+    y: 48,
+    kind: NodeKind.echo,
+    text: 'aside',
+    parentId: 'p',
+  );
+  const swatch = BoardNode(
+    id: 's',
+    boardId: 'b',
+    x: 400,
+    y: 80,
+    kind: NodeKind.swatch,
+    colorArgb: 0xFF000000,
+  );
+
+  test('moving a human slip takes its echo by the same delta', () {
+    final moved = NodeMotion.moved(
+      [parent, echo, swatch],
+      id: 'p',
+      dx: 16,
+      dy: -8,
+    );
+    expect(moved.singleWhere((n) => n.id == 'p').x, 26);
+    expect(moved.singleWhere((n) => n.id == 'p').y, 12);
+    expect(moved.singleWhere((n) => n.id == 'e').x, 274);
+    expect(moved.singleWhere((n) => n.id == 'e').y, 40);
+    expect(moved.singleWhere((n) => n.id == 's').x, 400);
+  });
+
+  test('moving an echo does not move the parent', () {
+    final moved = NodeMotion.moved([parent, echo], id: 'e', dx: 4, dy: 4);
+    expect(moved.singleWhere((n) => n.id == 'p').x, 10);
+    expect(moved.singleWhere((n) => n.id == 'e').x, 262);
+  });
+
+  test('unknown ids are a no-op', () {
+    expect(NodeMotion.moved([parent], id: 'missing', dx: 10, dy: 10), [parent]);
+  });
+}

--- a/test/features/canvas/echo_composer_test.dart
+++ b/test/features/canvas/echo_composer_test.dart
@@ -7,29 +7,48 @@ import 'package:penumbra/core/errors.dart';
 import 'package:penumbra/features/canvas/domain/echo_composer.dart';
 
 void main() {
-  test('local echo is non-empty, not a copy, and at most sixty words', () async {
-    const source = 'Private by default.';
-    final result = await const LocalEchoComposer().echo(source: source);
-    final text = result.okOrNull!;
-    expect(text, isNotEmpty);
-    expect(text, isNot(source));
-    expect(text.toLowerCase(), isNot(contains(source.toLowerCase().replaceAll('.', ''))));
-    expect(text.split(RegExp(r'\s+')).length, lessThanOrEqualTo(60));
-    expect(LocalEchoComposer.rephrase(source), text);
-    expect(text, isNot(contains('The same weather:')));
-  });
+  test(
+    'local echo is non-empty, not a copy, and at most sixty words',
+    () async {
+      const source = 'Private by default.';
+      final result = await const LocalEchoComposer().echo(source: source);
+      final text = result.okOrNull!;
+      expect(text, isNotEmpty);
+      expect(text, isNot(source));
+      expect(
+        text.toLowerCase(),
+        isNot(contains(source.toLowerCase().replaceAll('.', ''))),
+      );
+      expect(text.split(RegExp(r'\s+')).length, lessThanOrEqualTo(60));
+      expect(LocalEchoComposer.rephrase(source), text);
+      expect(text, isNot(contains('The same weather:')));
+    },
+  );
 
-  test('local echo offers a philosophical companion instead of concatenating the source', () async {
-    final sad = LocalEchoComposer.rephrase('I am sad');
-    expect(sad.toLowerCase(), isNot(contains('i am sad')));
-    expect(sad, anyOf(contains('Sorrow'), contains('hurts'), contains('Grief')));
+  test(
+    'local echo offers a philosophical companion instead of concatenating the source',
+    () async {
+      final sad = LocalEchoComposer.rephrase('I am sad');
+      expect(sad.toLowerCase(), isNot(contains('i am sad')));
+      expect(
+        sad,
+        anyOf(contains('Sorrow'), contains('hurts'), contains('Grief')),
+      );
 
-    final problem = LocalEchoComposer.rephrase('this is a problem');
-    expect(problem.toLowerCase(), isNot(contains('this is a problem')));
-    expect(problem, anyOf(contains('difficulty'), contains('problem is often'), contains('trouble')));
+      final problem = LocalEchoComposer.rephrase('this is a problem');
+      expect(problem.toLowerCase(), isNot(contains('this is a problem')));
+      expect(
+        problem,
+        anyOf(
+          contains('difficulty'),
+          contains('problem is often'),
+          contains('trouble'),
+        ),
+      );
 
-    expect(sad, isNot(problem));
-  });
+      expect(sad, isNot(problem));
+    },
+  );
 
   test('local echo refuses an empty slip', () async {
     final result = await const LocalEchoComposer().echo(source: '   ');
@@ -78,16 +97,25 @@ void main() {
 
   test('gemini 4xx fails closed', () async {
     final client = MockClient((request) async => http.Response('nope', 403));
-    final composer = GeminiEchoComposer(apiKey: 'k', systemPrompt: 'x', client: client);
+    final composer = GeminiEchoComposer(
+      apiKey: 'k',
+      systemPrompt: 'x',
+      client: client,
+    );
     final result = await composer.echo(source: 'A thought.');
     expect(result.errOrNull, isA<UnavailableFailure>());
   });
 
   test('empty model fails closed', () async {
     final client = MockClient(
-      (request) async => http.Response(json.encode({'candidates': <Object>[]}), 200),
+      (request) async =>
+          http.Response(json.encode({'candidates': <Object>[]}), 200),
     );
-    final composer = GeminiEchoComposer(apiKey: 'k', systemPrompt: 'x', client: client);
+    final composer = GeminiEchoComposer(
+      apiKey: 'k',
+      systemPrompt: 'x',
+      client: client,
+    );
     final result = await composer.echo(source: 'A thought.');
     expect(result.errOrNull, isA<UnavailableFailure>());
   });

--- a/test/features/canvas/echo_ritual_test.dart
+++ b/test/features/canvas/echo_ritual_test.dart
@@ -5,21 +5,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:penumbra/app/app.dart';
 import 'package:penumbra/app/providers.dart';
+import 'package:penumbra/core/errors.dart';
+import 'package:penumbra/core/result.dart';
 import 'package:penumbra/features/canvas/domain/echo_composer.dart';
 import 'package:penumbra/features/legal/presentation/legal_catalog.dart';
+import 'package:penumbra/features/privacy/domain/privacy_models.dart';
 import 'package:penumbra/features/studio/in_memory_studio.dart';
 
-InMemoryStudio studio() =>
-    InMemoryStudio(wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync());
+InMemoryStudio studio() => InMemoryStudio(
+  wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+);
 
 Future<void> pumpStudio(WidgetTester tester, InMemoryStudio s) async {
   tester.view.physicalSize = const Size(1400, 900);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
-  tester.platformDispatcher.accessibilityFeaturesTestValue = const FakeAccessibilityFeatures(
-    disableAnimations: true,
-  );
+  tester.platformDispatcher.accessibilityFeaturesTestValue =
+      const FakeAccessibilityFeatures(disableAnimations: true);
   addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
   await tester.pumpWidget(
     ProviderScope(
@@ -35,43 +38,109 @@ Future<void> pumpStudio(WidgetTester tester, InMemoryStudio s) async {
 }
 
 void main() {
-  testWidgets('summoning an echo with the local composer places a companion slip', (tester) async {
-    await pumpStudio(tester, studio());
+  testWidgets(
+    'summoning an echo with the local composer places a companion slip',
+    (tester) async {
+      await pumpStudio(tester, studio());
+      await tester.tap(find.text('Enter the studio'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(find.text('Quiet thoughts'), findsWidgets);
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(find.text('Private by default.'), findsWidgets);
+
+      await tester.tap(find.text('Private by default.').first);
+      await tester.pump();
+      await tester.ensureVisible(find.text('Summon an echo'));
+      await tester.tap(find.text('Summon an echo'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final echo = LocalEchoComposer.rephrase('Private by default.');
+      expect(find.text(echo), findsWidgets);
+      expect(find.text('Private by default.'), findsWidgets);
+      expect(find.text('Summon an echo'), findsNothing);
+      expect(find.text('Compose'), findsOneWidget);
+      expect(find.text('Place'), findsOneWidget);
+
+      await tester.tap(find.text(echo).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.text('Dismiss'), findsOneWidget);
+    },
+  );
+
+  test('privacy names the optional Google processor and consent basis', () {
+    expect(LegalCatalog.privacy.body, contains('Google LLC'));
+    expect(LegalCatalog.privacy.body, contains('Art. 6(1)(a)'));
+    expect(
+      LegalCatalog.privacy.body,
+      contains('rest of the board is not sent'),
+    );
+    expect(LegalCatalog.security.body, contains('ADR-007'));
+    expect(LegalCatalog.accessibility.body, contains('28 June 2025'));
+    expect(
+      LegalCatalog.accessibility.body,
+      contains('do not claim full EAA conformance'),
+    );
+  });
+
+  testWidgets('remote echo asks for Art. 6(1)(a) consent and records it', (
+    tester,
+  ) async {
+    final s = studio();
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    tester.platformDispatcher.accessibilityFeaturesTestValue =
+        const FakeAccessibilityFeatures(disableAnimations: true);
+    addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          studioProvider.overrideWithValue(s),
+          echoComposerProvider.overrideWithValue(const _RemoteEcho()),
+        ],
+        child: const PenumbraApp(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
     await tester.tap(find.text('Enter the studio'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 800));
-    expect(find.text('Quiet thoughts'), findsWidgets);
     await tester.tap(find.text('Open'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 800));
-    expect(find.text('Private by default.'), findsWidgets);
-
     await tester.tap(find.text('Private by default.').first);
     await tester.pump();
     await tester.ensureVisible(find.text('Summon an echo'));
     await tester.tap(find.text('Summon an echo'));
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 400));
-
-    final echo = LocalEchoComposer.rephrase('Private by default.');
-    expect(find.text(echo), findsWidgets);
-    expect(find.text('Private by default.'), findsWidgets);
-    expect(find.text('Summon an echo'), findsNothing);
-    expect(find.text('Compose'), findsOneWidget);
-    expect(find.text('Place'), findsOneWidget);
-
-    await tester.tap(find.text(echo).first);
-    await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
-    expect(find.text('Dismiss'), findsOneWidget);
+    expect(find.textContaining('Google LLC'), findsOneWidget);
+    expect(find.textContaining('Art. 6(1)(a)'), findsOneWidget);
+    await tester.tap(find.text('Send this thought'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.text('A remote aside.'), findsWidgets);
+    expect(
+      hasGrantedConsent((await s.consents()).okOrNull!, ConsentKind.remoteEcho),
+      isTrue,
+    );
   });
+}
 
-  test('privacy names the optional Google processor and consent basis', () {
-    expect(LegalCatalog.privacy.body, contains('Google LLC'));
-    expect(LegalCatalog.privacy.body, contains('Art. 6(1)(a)'));
-    expect(LegalCatalog.privacy.body, contains('rest of the board is not sent'));
-    expect(LegalCatalog.security.body, contains('ADR-007'));
-    expect(LegalCatalog.accessibility.body, contains('28 June 2025'));
-    expect(LegalCatalog.accessibility.body, contains('do not claim full EAA conformance'));
-  });
+class _RemoteEcho implements EchoComposer {
+  const _RemoteEcho();
+
+  @override
+  bool get remote => true;
+
+  @override
+  Future<Result<String, AppFailure>> echo({required String source}) async =>
+      const Ok('A remote aside.');
 }

--- a/test/features/canvas/node_semantics_test.dart
+++ b/test/features/canvas/node_semantics_test.dart
@@ -15,7 +15,14 @@ void main() {
   });
 
   test('empty text cards fall back to Untitled note', () {
-    const node = BoardNode(id: '1', boardId: 'b', x: 0, y: 0, kind: NodeKind.text, text: '  ');
+    const node = BoardNode(
+      id: '1',
+      boardId: 'b',
+      x: 0,
+      y: 0,
+      kind: NodeKind.text,
+      text: '  ',
+    );
     expect(node.semanticsLabel, 'Untitled note');
   });
 
@@ -54,7 +61,11 @@ void main() {
       text: 'Half-light',
       parentId: 'p1',
     );
-    final restored = BoardNode.fromPayload(id: node.id, boardId: node.boardId, payload: node.toPayload());
+    final restored = BoardNode.fromPayload(
+      id: node.id,
+      boardId: node.boardId,
+      payload: node.toPayload(),
+    );
     expect(restored.kind, NodeKind.echo);
     expect(restored.parentId, 'p1');
     expect(restored.text, 'Half-light');

--- a/test/features/canvas/recovery_phrase_ack_test.dart
+++ b/test/features/canvas/recovery_phrase_ack_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penumbra/app/app.dart';
+import 'package:penumbra/app/providers.dart';
+import 'package:penumbra/features/canvas/domain/echo_composer.dart';
+import 'package:penumbra/features/studio/in_memory_studio.dart';
+
+InMemoryStudio studio() => InMemoryStudio(
+  wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+);
+
+Future<void> pumpSignedIn(WidgetTester tester, InMemoryStudio s) async {
+  tester.view.physicalSize = const Size(1400, 900);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  tester.platformDispatcher.accessibilityFeaturesTestValue =
+      const FakeAccessibilityFeatures(disableAnimations: true);
+  addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        studioProvider.overrideWithValue(s),
+        echoComposerProvider.overrideWithValue(const LocalEchoComposer()),
+      ],
+      child: const PenumbraApp(),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
+}
+
+void main() {
+  testWidgets('recovery phrase can be acknowledged from the canvas', (
+    tester,
+  ) async {
+    final s = studio();
+    await s.signInWithGitHub();
+    await s.create(title: 'Quiet thoughts');
+    await pumpSignedIn(tester, s);
+    await tester.tap(find.text('Boards').first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 800));
+    expect(find.text('I have saved this phrase'), findsOneWidget);
+    await tester.tap(find.text('I have saved this phrase'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('I have saved this phrase'), findsNothing);
+    expect(s.pendingRecoveryPhrase, isNull);
+  });
+}

--- a/test/features/canvas/slip_edit_delete_test.dart
+++ b/test/features/canvas/slip_edit_delete_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penumbra/app/app.dart';
+import 'package:penumbra/app/providers.dart';
+import 'package:penumbra/features/canvas/domain/echo_composer.dart';
+import 'package:penumbra/features/studio/in_memory_studio.dart';
+
+InMemoryStudio studio() => InMemoryStudio(
+  wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+);
+
+Future<void> pumpStudio(WidgetTester tester, InMemoryStudio s) async {
+  tester.view.physicalSize = const Size(1400, 900);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  tester.platformDispatcher.accessibilityFeaturesTestValue =
+      const FakeAccessibilityFeatures(disableAnimations: true);
+  addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        studioProvider.overrideWithValue(s),
+        echoComposerProvider.overrideWithValue(const LocalEchoComposer()),
+      ],
+      child: const PenumbraApp(),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
+}
+
+Future<void> openSeededCanvas(WidgetTester tester) async {
+  await tester.tap(find.text('Enter the studio'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 800));
+  await tester.tap(find.text('Open'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 800));
+}
+
+void main() {
+  testWidgets('a selected human slip can be deleted after confirm', (
+    tester,
+  ) async {
+    await pumpStudio(tester, studio());
+    await openSeededCanvas(tester);
+    expect(find.text('Private by default.'), findsWidgets);
+
+    await tester.tap(find.text('Private by default.').first);
+    await tester.pump();
+    await tester.ensureVisible(find.text('Delete'));
+    await tester.tap(find.text('Delete'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.tap(find.text('Delete this note'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Private by default.'), findsNothing);
+  });
+
+  testWidgets('editing a human slip updates the Index', (tester) async {
+    await pumpStudio(tester, studio());
+    await openSeededCanvas(tester);
+    await tester.tap(find.text('Private by default.').first);
+    await tester.pump();
+    await tester.ensureVisible(find.text('Edit'));
+    await tester.tap(find.text('Edit'));
+    await tester.pump();
+    await tester.enterText(
+      find.byType(EditableText).last,
+      'Corrected in the half-light.',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.text('Corrected in the half-light.'), findsWidgets);
+  });
+}

--- a/test/features/studio_contract_test.dart
+++ b/test/features/studio_contract_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:penumbra/core/errors.dart';
 import 'package:penumbra/features/auth/domain/auth_models.dart';
 import 'package:penumbra/features/boards/domain/board.dart';
+import 'package:penumbra/features/privacy/domain/privacy_models.dart';
 import 'package:penumbra/features/studio/in_memory_studio.dart';
 import 'package:penumbra/features/studio/studio_repositories.dart';
 import 'package:uuid/uuid.dart';
@@ -14,30 +15,47 @@ void main() {
   late InMemoryCanvasRepository canvas;
 
   setUp(() async {
-    studio = InMemoryStudio(wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync());
+    studio = InMemoryStudio(
+      wordlist: File('assets/crypto/bip39_english.txt').readAsLinesSync(),
+    );
     boards = InMemoryBoardRepository(studio);
     canvas = InMemoryCanvasRepository(studio);
   });
 
-  test('password sign-up rejects short secrets and accepts a 12-character secret', () async {
-    final short = await studio.signUpWithPassword(email: 'ada@penumbra.studio', password: 'short');
-    expect(short.errOrNull, isA<WeakSecretFailure>());
+  test(
+    'password sign-up rejects short secrets and accepts a 12-character secret',
+    () async {
+      final short = await studio.signUpWithPassword(
+        email: 'ada@penumbra.studio',
+        password: 'short',
+      );
+      expect(short.errOrNull, isA<WeakSecretFailure>());
 
-    final ok = await studio.signUpWithPassword(email: 'ada@penumbra.studio', password: 'long-enough-1');
-    expect(ok.okOrNull?.email, 'ada@penumbra.studio');
-    expect(ok.okOrNull?.methods, contains(AuthMethod.password));
-  });
+      final ok = await studio.signUpWithPassword(
+        email: 'ada@penumbra.studio',
+        password: 'long-enough-1',
+      );
+      expect(ok.okOrNull?.email, 'ada@penumbra.studio');
+      expect(ok.okOrNull?.methods, contains(AuthMethod.password));
+    },
+  );
 
-  test('passkey, Google, GitHub and magic link all establish a session', () async {
-    expect((await studio.signInWithPasskey()).isOk, isTrue);
-    await studio.signOut();
-    expect((await studio.signInWithGoogle()).isOk, isTrue);
-    await studio.signOut();
-    expect((await studio.signInWithGitHub()).isOk, isTrue);
-    await studio.signOut();
-    expect((await studio.sendMagicLink(email: 'link@penumbra.studio')).isOk, isTrue);
-    expect(studio.current?.email, 'link@penumbra.studio');
-  });
+  test(
+    'passkey, Google, GitHub and magic link all establish a session',
+    () async {
+      expect((await studio.signInWithPasskey()).isOk, isTrue);
+      await studio.signOut();
+      expect((await studio.signInWithGoogle()).isOk, isTrue);
+      await studio.signOut();
+      expect((await studio.signInWithGitHub()).isOk, isTrue);
+      await studio.signOut();
+      expect(
+        (await studio.sendMagicLink(email: 'link@penumbra.studio')).isOk,
+        isTrue,
+      );
+      expect(studio.current?.email, 'link@penumbra.studio');
+    },
+  );
 
   test('OAuth users receive a 12-word recovery phrase once', () async {
     final user = (await studio.signInWithGitHub()).okOrNull!;
@@ -48,11 +66,17 @@ void main() {
   });
 
   test('boards are isolated between users (RLS contract)', () async {
-    await studio.signUpWithPassword(email: 'ada@penumbra.studio', password: 'long-enough-1');
+    await studio.signUpWithPassword(
+      email: 'ada@penumbra.studio',
+      password: 'long-enough-1',
+    );
     final board = (await boards.create(title: 'Ada only')).okOrNull!;
 
     await studio.signOut();
-    await studio.signUpWithPassword(email: 'grace@penumbra.studio', password: 'long-enough-2');
+    await studio.signUpWithPassword(
+      email: 'grace@penumbra.studio',
+      password: 'long-enough-2',
+    );
     final stolen = await boards.getById(board.id);
     expect(stolen.errOrNull, isA<ForbiddenFailure>());
     expect((await boards.listMine()).okOrNull, isEmpty);
@@ -73,66 +97,158 @@ void main() {
     final stored = studio.debugCipherStorage(node.id)!;
     expect(stored.contains('plaintext-must-not-persist'), isFalse);
     final loaded = (await canvas.listNodes(board.id)).okOrNull!;
-    expect(loaded.where((n) => n.id == node.id).single.text, 'plaintext-must-not-persist');
-  });
-
-  test('echo payloads are stored encrypted and a second summon is refused', () async {
-    await studio.enterDemoStudio();
-    final board = (await boards.listMine()).okOrNull!.first;
-    final nodes = (await canvas.listNodes(board.id)).okOrNull!;
-    final parent = nodes.firstWhere((n) => n.kind == NodeKind.text);
-    final echo = BoardNode(
-      id: const Uuid().v4(),
-      boardId: board.id,
-      x: parent.x + 28,
-      y: parent.y + 36,
-      kind: NodeKind.echo,
-      text: 'echo-plaintext-must-not-persist',
-      parentId: parent.id,
+    expect(
+      loaded.where((n) => n.id == node.id).single.text,
+      'plaintext-must-not-persist',
     );
-    expect((await canvas.upsert(echo)).isOk, isTrue);
-    final stored = studio.debugCipherStorage(echo.id)!;
-    expect(stored.contains('echo-plaintext-must-not-persist'), isFalse);
-    final loaded = (await canvas.listNodes(board.id)).okOrNull!;
-    expect(loaded.where((n) => n.id == echo.id).single.text, 'echo-plaintext-must-not-persist');
-    expect(loaded.where((n) => n.id == echo.id).single.parentId, parent.id);
-
-    final second = BoardNode(
-      id: const Uuid().v4(),
-      boardId: board.id,
-      x: parent.x + 40,
-      y: parent.y + 40,
-      kind: NodeKind.echo,
-      text: 'another',
-      parentId: parent.id,
-    );
-    expect((await canvas.upsert(second)).errOrNull, isA<ValidationFailure>());
-
-    expect((await canvas.delete(echo.id)).isOk, isTrue);
-    expect((await canvas.upsert(second)).isOk, isTrue);
   });
 
-  test('export contains the user data and erasure removes it after re-auth', () async {
-    await studio.signUpWithPassword(email: 'ada@penumbra.studio', password: 'long-enough-1');
-    await boards.create(title: 'Keep');
-    final exported = (await studio.exportMine()).okOrNull!;
-    expect(exported.boards, isNotEmpty);
-    expect(exported.profile['email'], 'ada@penumbra.studio');
+  test(
+    'echo payloads are stored encrypted and a second summon is refused',
+    () async {
+      await studio.enterDemoStudio();
+      final board = (await boards.listMine()).okOrNull!.first;
+      final nodes = (await canvas.listNodes(board.id)).okOrNull!;
+      final parent = nodes.firstWhere((n) => n.kind == NodeKind.text);
+      final echo = BoardNode(
+        id: const Uuid().v4(),
+        boardId: board.id,
+        x: parent.x + 28,
+        y: parent.y + 36,
+        kind: NodeKind.echo,
+        text: 'echo-plaintext-must-not-persist',
+        parentId: parent.id,
+      );
+      expect((await canvas.upsert(echo)).isOk, isTrue);
+      final stored = studio.debugCipherStorage(echo.id)!;
+      expect(stored.contains('echo-plaintext-must-not-persist'), isFalse);
+      final loaded = (await canvas.listNodes(board.id)).okOrNull!;
+      expect(
+        loaded.where((n) => n.id == echo.id).single.text,
+        'echo-plaintext-must-not-persist',
+      );
+      expect(loaded.where((n) => n.id == echo.id).single.parentId, parent.id);
 
-    expect((await studio.eraseAccount(password: 'wrong-password')).isErr, isTrue);
-    expect((await studio.eraseAccount(password: 'long-enough-1')).isOk, isTrue);
-    expect(studio.current, isNull);
-    await studio.signUpWithPassword(email: 'ada@penumbra.studio', password: 'long-enough-1');
-    expect((await boards.listMine()).okOrNull, isEmpty);
-  });
+      final second = BoardNode(
+        id: const Uuid().v4(),
+        boardId: board.id,
+        x: parent.x + 40,
+        y: parent.y + 40,
+        kind: NodeKind.echo,
+        text: 'another',
+        parentId: parent.id,
+      );
+      expect((await canvas.upsert(second)).errOrNull, isA<ValidationFailure>());
+
+      expect((await canvas.delete(echo.id)).isOk, isTrue);
+      expect((await canvas.upsert(second)).isOk, isTrue);
+    },
+  );
+
+  test(
+    'export contains the user data and erasure removes it after re-auth',
+    () async {
+      await studio.signUpWithPassword(
+        email: 'ada@penumbra.studio',
+        password: 'long-enough-1',
+      );
+      await boards.create(title: 'Keep');
+      final exported = (await studio.exportMine()).okOrNull!;
+      expect(exported.boards, isNotEmpty);
+      expect(exported.profile['email'], 'ada@penumbra.studio');
+
+      expect(
+        (await studio.eraseAccount(password: 'wrong-password')).isErr,
+        isTrue,
+      );
+      expect(
+        (await studio.eraseAccount(password: 'long-enough-1')).isOk,
+        isTrue,
+      );
+      expect(studio.current, isNull);
+      await studio.signUpWithPassword(
+        email: 'ada@penumbra.studio',
+        password: 'long-enough-1',
+      );
+      expect((await boards.listMine()).okOrNull, isEmpty);
+    },
+  );
 
   test('restricted boards refuse writes (Art. 18)', () async {
     await studio.enterDemoStudio();
     final board = (await boards.listMine()).okOrNull!.first;
     await boards.setRestricted(id: board.id, restricted: true);
     final write = await canvas.upsert(
-      BoardNode(id: 'n1', boardId: board.id, x: 0, y: 0, kind: NodeKind.text, text: 'nope'),
+      BoardNode(
+        id: 'n1',
+        boardId: board.id,
+        x: 0,
+        y: 0,
+        kind: NodeKind.text,
+        text: 'nope',
+      ),
     );
     expect(write.errOrNull, isA<ForbiddenFailure>());
+    final existing = (await canvas.listNodes(board.id)).okOrNull!.first;
+    expect(
+      (await canvas.delete(existing.id)).errOrNull,
+      isA<ForbiddenFailure>(),
+    );
+  });
+
+  test('deleting a human slip cascades its encrypted echo', () async {
+    await studio.enterDemoStudio();
+    final board = (await boards.listMine()).okOrNull!.first;
+    final parent = (await canvas.listNodes(
+      board.id,
+    )).okOrNull!.firstWhere((n) => n.kind == NodeKind.text);
+    final echo = BoardNode(
+      id: const Uuid().v4(),
+      boardId: board.id,
+      x: parent.x + 28,
+      y: parent.y + 36,
+      kind: NodeKind.echo,
+      text: 'cascade-echo-plaintext',
+      parentId: parent.id,
+    );
+    expect((await canvas.upsert(echo)).isOk, isTrue);
+    expect(studio.debugCipherStorage(echo.id), isNotNull);
+    expect((await canvas.delete(parent.id)).isOk, isTrue);
+    expect(studio.debugCipherStorage(parent.id), isNull);
+    expect(studio.debugCipherStorage(echo.id), isNull);
+    final left = (await canvas.listNodes(board.id)).okOrNull!;
+    expect(left.where((n) => n.id == parent.id || n.id == echo.id), isEmpty);
+  });
+
+  test('remote echo consent is recorded and exported', () async {
+    await studio.signUpWithPassword(
+      email: 'ada@penumbra.studio',
+      password: 'long-enough-1',
+    );
+    expect(
+      hasGrantedConsent(
+        (await studio.consents()).okOrNull!,
+        ConsentKind.remoteEcho,
+      ),
+      isFalse,
+    );
+    expect(
+      (await studio.recordConsent(ConsentKind.remoteEcho, granted: true)).isOk,
+      isTrue,
+    );
+    expect(
+      hasGrantedConsent(
+        (await studio.consents()).okOrNull!,
+        ConsentKind.remoteEcho,
+      ),
+      isTrue,
+    );
+    final exported = (await studio.exportMine()).okOrNull!;
+    expect(
+      exported.consents.any(
+        (row) => row['kind'] == 'remoteEcho' && row['granted'] == true,
+      ),
+      isTrue,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Deepens the existing studio ritual: edit/delete/move slips, Art. 18 board rights, persisted echo consent, cloud WebAuthn passkeys, making-of chapter 09 (`1.1.0+2`).
- Adopts SemVer + GitHub Flow: never commit on `main`; branches are `{bump}/vX.Y.Z-{slug}` (`docs/versioning.md`).
- CI on every PR now requires **analyze**, **test** (in-memory ritual flows), **build-web**, and **supply-chain**. Deploy stays `main`-only.

Issues #6–#13 are already closed; this PR is the code landing those slices plus the versioning/CI rules.

## Test plan
- [ ] CI jobs `analyze`, `test`, `build-web`, and `supply-chain` are green on this PR
- [ ] `flutter test` locally covers echo, edit/delete, restrict, recovery phrase, studio contract
- [ ] Enter the in-memory studio: Place, Edit, Delete, Move, Restrict a board, recovery-phrase acknowledge
- [ ] Confirm no Cloudflare deploy runs on the PR
- [ ] After merge (optional): enable branch protection on `main` requiring those four checks


Made with [Cursor](https://cursor.com)