### PR TITLE
v1.1.1: Week 5–8 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Read this first. Product is small; craft is the interview artifact.
 
 ## GitHub Issues + Project (development board)
 
-GitHub is the process board, not a product feature. See `docs/github.md`. Four-week enhancement spec: `docs/roadmap.md`. Repo: https://github.com/sebbeflebbe/penumbra Board: https://github.com/users/sebbeflebbe/projects/2
+GitHub is the process board, not a product feature. See `docs/github.md`. Weeks 5–8 enhancement spec: `docs/roadmap.md` (issues #15–#22). Repo: https://github.com/sebbeflebbe/penumbra Board: https://github.com/users/sebbeflebbe/projects/2
 
 1. Before coding a slice: create or pick the issue; add `status:in-progress` (Project: **In Progress**).
 2. When the slice lands: comment with what changed; close the issue (Project: **Done**). PRs use `Fixes #N`.

--- a/docs/github.md
+++ b/docs/github.md
@@ -20,8 +20,16 @@ Issues:
 - https://github.com/sebbeflebbe/penumbra/issues/11 Unavailable-path tests + honest copy (Done)
 - https://github.com/sebbeflebbe/penumbra/issues/12 A11y lockstep after new controls (Done)
 - https://github.com/sebbeflebbe/penumbra/issues/13 Env/imprint/ADR/story/OSV hygiene (Done)
+- https://github.com/sebbeflebbe/penumbra/issues/15 Phrase unlock when the device wrap is gone
+- https://github.com/sebbeflebbe/penumbra/issues/16 Withdraw remote-echo consent (Art. 7(3))
+- https://github.com/sebbeflebbe/penumbra/issues/17 Register a passkey from an existing session
+- https://github.com/sebbeflebbe/penumbra/issues/18 Art. 16 display name + Art. 20 downloadable export
+- https://github.com/sebbeflebbe/penumbra/issues/19 Split canvas_page.dart with no behaviour change
+- https://github.com/sebbeflebbe/penumbra/issues/20 Index / Move a11y deepening
+- https://github.com/sebbeflebbe/penumbra/issues/21 Test holes for already-shipped UI
+- https://github.com/sebbeflebbe/penumbra/issues/22 Story / ADR / origin runbook / 1.2.0 honesty
 
-Four-week spec: [roadmap.md](roadmap.md). Versioning and GitHub Flow: [versioning.md](versioning.md).
+Four-week spec (Weeks 5–8): [roadmap.md](roadmap.md). Versioning and GitHub Flow: [versioning.md](versioning.md).
 
 ## Ritual
 
@@ -32,7 +40,8 @@ Four-week spec: [roadmap.md](roadmap.md). Versioning and GitHub Flow: [versionin
 ## Labels
 
 - `status:in-progress` — this chat (or a PR) is working the slice.
-- `week-1` … `week-4` — four-week enhancement slices.
+- `week-1` … `week-4` — first deepening (shipped).
+- `week-5` … `week-8` — current enhancement slices.
 
 Opened issues land in **Todo**. Closed issues land in **Done**. `.github/workflows/project.yml` keeps the Project Status field in sync when `PROJECTS_TOKEN` and `PENUMBRA_PROJECT_NUMBER` are set.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,328 +1,410 @@
-# Penumbra four-week enhancement roadmap
+# Penumbra Weeks 5–8 enhancement roadmap
 
-Canonical spec for GitHub Issues #6–#13. Development board: [docs/github.md](github.md). Principles: [AGENTS.md](../AGENTS.md).
+Canonical spec for GitHub Issues #15–#22. Development board: [docs/github.md](github.md). Principles: [AGENTS.md](../AGENTS.md). Versioning: [docs/versioning.md](versioning.md).
 
 This is process, not a product feature. No in-studio Kanban.
 
 Stay inside [AGENTS.md](../AGENTS.md): one ritual, cloud real when configured, passkeys first, EN 301 549 bar, TDD, making-of in lockstep. No in-studio Kanban, sharing, or extra dashboards.
 
-
 ```mermaid
 flowchart LR
-  capture[Docs_and_Issues] --> w1[Week1_Canvas]
-  w1 --> w2[Week2_Rights]
-  w2 --> w3[Week3_Passkeys]
-  w3 --> w4[Week4_Honesty]
+  spec[Docs_and_Issues] --> w5[Week5_Unlock]
+  w5 --> w6[Week6_Passkey_rights]
+  w6 --> w7[Week7_Canvas_a11y]
+  w7 --> w8[Week8_Honesty]
 ```
+
+## Shipped — Weeks 1–4 (#6–#13)
+
+Landed on `main` as **v1.1.0** ([PR #14](https://github.com/sebbeflebbe/penumbra/pull/14)). Retrospective: [docs/story/09-roadmap.md](story/09-roadmap.md).
+
+- #6 Edit and delete human slips (restricted `deleteNode`, `paper_slip.dart`)
+- #7 Move handle + acknowledge recovery phrase
+- #8 Board rename, delete, Art. 18 restrict
+- #9 Persist `ConsentKind.remoteEcho` + erase re-auth
+- #10 Cloud WebAuthn passkeys (phrase wrap; in-memory still fake)
+- #11 Unavailable-path tests + honest copy
+- #12 A11y lockstep after new controls
+- #13 Env / imprint / ADR / story / OSV hygiene
+
+The full Week 1–4 issue text is in git at that merge. Do not re-open those issues.
 
 ## Frozen constraints (every week)
 
-- **Do not bump Forui.** Pinned at `forui: 0.22.2` because 0.26 needs Flutter 3.47 ([docs/adr/001-stack.md](docs/adr/001-stack.md)). CI is `FLUTTER_VERSION: "3.44.1"` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+- **Do not bump Forui.** Pinned at `forui: 0.22.2` because 0.26 needs Flutter 3.47 ([docs/adr/001-stack.md](docs/adr/001-stack.md)). CI is `FLUTTER_VERSION: "3.44.1"` in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 - **Do not bump Flutter** in CI unless a CVE forces it; if you must, re-evaluate Forui (likely blocked).
-- Domain has no Flutter and no Supabase. Tests use [InMemoryStudio](lib/features/studio/in_memory_studio.dart). CI never gets `SUPABASE_*` dart-defines.
-- Card bodies stay AES-256-GCM in the browser. Echoes still send **one slip** after Art. 6(1)(a), or local ([docs/adr/007-echo.md](docs/adr/007-echo.md)).
+- Domain has no Flutter and no Supabase. Tests use [InMemoryStudio](../lib/features/studio/in_memory_studio.dart). CI never gets `SUPABASE_*` dart-defines.
+- Card bodies stay AES-256-GCM in the browser. Echoes still send **one slip** after Art. 6(1)(a), or local ([docs/adr/007-echo.md](adr/007-echo.md)).
 - Honesty: no CE / NIS2 entity / ISO 27001 / full EAA claims.
+- In-memory OAuth / passkey / magic stay **fake**. Do not make them real.
+- **WebAuthn PRF is not a committed issue.** Phrase wrap stays the DEK story ([docs/adr/002-key-wrapping.md](adr/002-key-wrapping.md)).
 
 ## Current versions (baseline)
 
-- App: `1.0.0+1` in [pubspec.yaml](pubspec.yaml)
+- App on `main` after this spec PR: `1.1.1+3` in [pubspec.yaml](../pubspec.yaml) (docs-only patch). Product work for #15–#22 starts on `minor/v1.2.0-…` at **`1.2.0+4`** (never reuse a build number).
 - SDK: `^3.12.1`; Flutter CI `3.44.1`
 - Notable deps: `forui 0.22.2`, `flutter_riverpod ^2.6.1`, `go_router ^15.1.2`, `cryptography ^2.7.0`, `supabase_flutter ^2.9.0`, `web ^1.1.1`, `flutter_lints ^6.0.0`
-- App version stays `1.0.0+1` through Weeks 1–3; Week 4 bumps to **`1.1.0+2`** once the ritual UI matches the domain.
+- App version stays `1.1.1+3` on this spec branch. The first product PR bumps to **`1.2.0+4`**. Week 8 (#22) is the honesty pass on that product PR (or a follow-up on the same minor), not a second SemVer bump.
 
 ## Known code facts the issues must name
 
-- Canvas UI is one ~1067-line file: [lib/features/canvas/presentation/canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart). Extract when touching it; do not grow it blindly.
-- `CanvasRepository.delete` already exists and **cascades child echoes** in both studios. UI only calls it from `_dismissEcho`.
-- `deleteNode` in memory ([in_memory_studio.dart](lib/features/studio/in_memory_studio.dart) ~471) and cloud ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~448) **does not check `board.restricted`**. `upsert` does. Exposing human-delete without that check breaks Art. 18.
-- `_nudge` already moves a parent’s echo by the same delta (~163–186) but **swallows** upsert errors (`err: (_) {}`). Restricted boards fail silently today.
-- Recovery phrase `FAlert` is shown when `pendingRecoveryPhrase != null` (~431–438) but nothing calls `acknowledgeRecoveryPhrase()`.
-- Echo consent is a canvas field `_echoConsentedThisSession`. `ConsentKind` is only `necessaryStorage | termsOfUse`. Table `consent_events.kind` is unconstrained `text` ([0001_init.sql](supabase/migrations/0001_init.sql)); no SQL enum migration required.
-- Privacy erase UI calls `eraseAccount()` with **no password** ([privacy_page.dart](lib/features/privacy/presentation/privacy_page.dart) ~40). Studio contract already requires the password ([studio_contract_test.dart](test/features/studio_contract_test.dart) ~115).
-- Cloud passkeys always `AuthUnavailableFailure` ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~177–189). In-memory fakes a session as `passkey-ada@penumbra.studio`.
-- `.env.example` still has `LUMEN_*`; [config.dart](lib/core/config.dart) already reads `PENUMBRA_*`.
+- Cloud hydrate can leave a signed-in `AuthUser` with `_sessionDek == null` when wrap exists in `profiles` but the local device store does not ([supabase_studio.dart](../lib/features/studio/supabase_studio.dart) ~865–898). `listNodes` then returns `UnauthenticatedFailure` (~487–489). Password sign-in treats a missing DEK as `InvalidCredentialsFailure` (~114–116); OAuth/passkey session restore does not. There is **no** `unlockWithRecoveryPhrase` on [AuthRepository](../lib/features/auth/domain/auth_models.dart).
+- Device wrap keys: `penumbra.device_key.$userId` / `penumbra.device_wrapped.$userId` via `_rememberDevice` / `_unlockDevice` (~968–990).
+- `registerPasskey()` is implemented on both studios ([in_memory_studio.dart](../lib/features/studio/in_memory_studio.dart) ~250, [supabase_studio.dart](../lib/features/studio/supabase_studio.dart) ~251). **No widget calls it.** In-memory already adds `AuthMethod.passkey` on the current account.
+- `hasGrantedConsent` is `.any(kind && granted)` ([privacy_models.dart](../lib/features/privacy/domain/privacy_models.dart) ~105–107). A later `granted: false` row **does not** withdraw. Canvas loads that helper into `_echoConsented` ([canvas_page.dart](../lib/features/canvas/presentation/canvas_page.dart) ~72–75).
+- Privacy UI: Export + Copy JSON + Erase. No withdraw control, no display-name field, no file download ([privacy_page.dart](../lib/features/privacy/presentation/privacy_page.dart)). Export JSON already includes `displayName` (~735 / ~674). `profiles.display_name` exists ([0001_init.sql](../supabase/migrations/0001_init.sql)). Legal catalog names access, port, restrict, erase — **not Art. 16** ([legal_catalog.dart](../lib/features/legal/presentation/legal_catalog.dart) ~28).
+- [canvas_page.dart](../lib/features/canvas/presentation/canvas_page.dart) is ~1230 lines. `paper_slip.dart` is extracted. Still inlined: `_Atelier` (~587), `_ComposeBar` (~839), `_CardIndex` (~952). Index is a `ListView` of `GestureDetector`s; no roving tabindex; no position announce after Move.
+- [docs/story/01-stack.md](story/01-stack.md) still says “planned Supabase EU path”. ADR-001 and making-of chapter 01 already say live Frankfurt. Chapter 09 is the last catalog chapter ([story_catalog.dart](../lib/features/story/data/story_catalog.dart)).
+- Board **Restrict** has a widget test ([board_lifecycle_test.dart](../test/features/boards/board_lifecycle_test.dart)). Rename/delete UI do not. Move is domain-tested ([node_motion_test.dart](../test/features/boards/node_motion_test.dart)), not as a widget. `registerPasskey` has no contract test.
 
 ---
 
-## Week 1 — Finish the canvas ritual
+## Week 5 — Encryption honesty
 
-**Goal:** Place is not write-only. Keep Index, hairlines, and encryption behaviour identical.
+**Goal.** A signed-in cloud session can decrypt again after the device wrap is gone, and Art. 6(1)(a) echo consent is withdrawable.
 
-### Issue #6 — Edit and delete human slips
+### Issue #15 — Phrase unlock when the device wrap is gone
 
-**Why.** `_PaperSlip` only offers Dismiss for echoes. Humans can Place forever and never correct a typo. `CanvasRepository.delete` and echo cascade are already implemented.
+**Why.** OAuth and passkey users wrap the DEK with a twelve-word phrase shown once. Returning on a new browser (or after clearing site data) hydrates the Auth session, finds `wrap_salt` / `wrapped_dek`, fails `_unlockDevice`, and leaves `_sessionDek == null`. The person is “signed in” with an empty studio. That is an interview killer: the phrase was the honesty of ADR-002, and there is no field to type it.
 
 **Acceptance**
 
-- Selected **text** (and **swatch**) slips expose named controls: **Edit** (text only), **Delete**. Echoes stay Dismiss-only; echo body is not editable.
-- Edit: in-place field or compose-bar reuse; empty body refused; `upsert` re-encrypts the full payload (`toPayload()` already includes `text`/`x`/`y`/`parentId`).
-- Delete human: confirm dialog with named buttons (not an icon-only trash). Studio cascade removes the child echo; UI drops both from `_nodes` and repairs `_focusedIndex`. Index numerals update via `EchoPairing.conversation`.
-- Restricted board: delete and edit must `ForbiddenFailure` and `announce` the Art. 18 message. Domain test first: `deleteNode` on a restricted board is `ForbiddenFailure` (this is a **new** studio check, both implementations).
-- 48px-class targets; Semantics labels (`Edit this note`, `Delete this note`). High-contrast: no extra shadow; reduced motion: no extra animation ([motion.dart](lib/core/a11y/motion.dart)).
+- Add `AuthRepository.unlockWithRecoveryPhrase(String phrase)` (name may vary; keep it named and domain-level). Wrong checksum / wrong phrase → `InvalidCredentialsFailure` (or a dedicated failure with honest copy). Success unwraps, sets `_sessionDek`, `_rememberDevice`, and canvas `listNodes` works.
+- UI: when `current != null` and the studio cannot decrypt (session without DEK), show a **locked studio** surface — not a blank board. Named field + **Unlock** (48px-class). Do not dump the person back to password sign-in if their method is OAuth/passkey.
+- In-memory: expose a test seam so contract tests can drop the session DEK (or skip device remember) and still round-trip the phrase. Do not change demo `enterDemoStudio` (it has a wrapping secret, not a user-facing phrase).
+- 12 words, existing checksum rules. Do not log the phrase. Do not persist plaintext phrase.
+- Semantics: `Unlock with recovery phrase`. Reduced motion: no extra animation.
 
 **Implementation**
 
-- Add `restricted` check to `deleteNode` in both studios (mirror `upsert`).
-- Extract `_PaperSlip` (+ edit state) out of `canvas_page.dart` if the file would grow; prefer `lib/features/canvas/presentation/paper_slip.dart`.
-- `_ComposeBar`: when a text slip is selected, Place can become Save, or keep Place and add Edit on the slip. Prefer slip-local edit so Index/canvas stay one ritual.
-- Do not add a properties panel.
+- Domain first on `InMemoryStudio`, then the same method on `SupabaseStudio` (call existing `_unwrapDek` with the typed phrase).
+- Prefer a small widget on canvas or boards (`locked_studio.dart`) rather than a new route. Chrome can stay signed-in (Sign out still works).
+- Password users who already unwrap with the password on sign-in should not see this surface.
+- After unlock, `announce` “Notes unlocked.”
 
 **Files**
 
-- [lib/features/studio/in_memory_studio.dart](lib/features/studio/in_memory_studio.dart), [lib/features/studio/supabase_studio.dart](lib/features/studio/supabase_studio.dart) (`deleteNode`)
-- [lib/features/canvas/presentation/canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart), likely new `paper_slip.dart`
-- [test/features/studio_contract_test.dart](test/features/studio_contract_test.dart)
-- New `test/features/canvas/slip_edit_delete_test.dart` (widget, pattern from [echo_ritual_test.dart](test/features/canvas/echo_ritual_test.dart): `pumpStudio`, disable animations, 1400×900)
+- [lib/features/auth/domain/auth_models.dart](../lib/features/auth/domain/auth_models.dart)
+- [lib/features/studio/in_memory_studio.dart](../lib/features/studio/in_memory_studio.dart), [lib/features/studio/supabase_studio.dart](../lib/features/studio/supabase_studio.dart)
+- Canvas or boards presentation; possibly [lib/shared/widgets/chrome.dart](../lib/shared/widgets/chrome.dart)
+- [test/features/studio_contract_test.dart](../test/features/studio_contract_test.dart)
+- New widget test `test/features/auth/phrase_unlock_test.dart` (`pumpStudio` pattern from [echo_ritual_test.dart](../test/features/canvas/echo_ritual_test.dart))
 
-**Tests (write first)**
+**Tests (TDD first)**
 
-- Domain: delete human with echo → both gone; ciphertext gone from `debugCipherStorage`.
-- Domain: restricted `deleteNode` → `ForbiddenFailure`.
-- Widget: Enter studio → Open → select seeded “Private by default.” → Delete → confirm → text gone; Index no longer lists it.
-- Widget: Edit that slip → Save → Index shows new text; `semanticsLabel` follows `BoardNode.semanticsLabel`.
+- Domain: federated sign-in → acknowledge phrase → drop session DEK / device wrap → `listNodes` fails or returns unauthenticated → `unlockWithRecoveryPhrase` with the saved phrase → nodes decrypt. Wrong phrase fails and DEK stays null.
+- Widget: pump locked chrome → enter phrase → Unlock → seeded slip text visible.
+- Existing recovery-phrase **ack** test stays green ([recovery_phrase_ack_test.dart](../test/features/canvas/recovery_phrase_ack_test.dart)).
 
 **Difficulties**
 
-- `canvas_page.dart` size and private widgets (`_PaperSlip`, `_Atelier`). Extraction will churn diffs; keep visual parity (borders, Fraunces numerals, copper selected state).
-- Widget tests that tap slips inside `InteractiveViewer` are fragile (see existing `find.text('Private by default.').first`). Prefer `ensureVisible` + first match; set `disableAnimations`.
-- Confirm dialog: Forui `showFDialog` already used for echo consent — reuse that pattern, not `AlertDialog`.
-- Do not decrypt in the UI; only call `upsert`/`delete`.
+- In-memory accounts keep `dek` on the account object; you must simulate “wrap exists, session DEK gone” without deleting the wrap secret. Add `debugLockSession()` (or equivalent) rather than hacking private fields from tests.
+- Cloud: `_onSession` currently `_setCurrent` even when `dek == null`. After this issue, that state must be distinguishable in the UI (`needsPhraseUnlock` on `AuthUser`, or a studio getter). Do not overload `needsRecoveryPhraseReveal` (that means “copy this new phrase”).
+- BIP39 checksum vs “any 12 words”: follow whatever `_newPhrase` already uses; don’t invent a second wordlist.
 
 **Deps / bumps.** None.
 
-**Docs.** One paragraph in chapter 03 or 09 that Place is reversible. No ADR unless delete-on-restricted behaviour was undocumented (it was a hole).
+**Docs.** One sentence in ADR-002: phrase is also the **re-unlock** secret, not only first-wrap. Story 02 if the copy still implies “shown once and then unused.”
 
-**Out of scope.** Drag (issue #7). Echo body edit. Rich text.
+**Out of scope.** WebAuthn PRF. Changing the wrap algorithm. Syncing device wrap across browsers without the phrase.
 
-### Issue #7 — Drag-move slips + acknowledge recovery phrase
+### Issue #16 — Withdraw remote-echo consent (Art. 7(3))
 
-**Why.** Arrow keys already persist via `_nudge` (16px). Pointer users cannot move. Recovery phrase alert never clears `needsRecoveryPhraseReveal`, so it can haunt the chrome forever.
+**Why.** Week 2 persisted `remoteEcho` across sessions and explicitly skipped withdraw. Grant is forever. Art. 7(3) requires it to be as easy to withdraw as to give. Canvas uses `hasGrantedConsent`, which is true if **any** historical row is granted — a new `granted: false` row would be ignored.
 
 **Acceptance**
 
-- Pointer drag on a focused slip persists `x`/`y` through `upsert`. Keyboard nudge still works.
-- Dragging a **text** parent moves its echo by the same delta (copy `_nudge` ~174–183). Then run existing `_untangleEchoes` if overlap.
-- `InteractiveViewer` pan/zoom still works on empty sheet; drag on a slip must not pan the viewport (gesture conflict is the hard part).
-- Reduced motion: drag still works; skip `penumbraCardAppear` extras only.
-- Recovery phrase alert gains a named button **I have saved this phrase** → `acknowledgeRecoveryPhrase()`; phrase disappears; in-memory test already covers the API ([studio_contract_test.dart](test/features/studio_contract_test.dart) ~42–48).
+- Privacy page: named control **Withdraw echo consent** (visible when the latest `remoteEcho` event is granted). Confirm with Forui dialog (same pattern as erase/delete). After withdraw, announce and canvas summons the consent dialog again.
+- `recordConsent(ConsentKind.remoteEcho, granted: false)` appends a row. **Do not delete** historical consent rows (audit). Change `hasGrantedConsent` to **latest-wins** per kind (sort by `at`, then granted flag).
+- Export JSON still lists all events; UI copy says withdrawal does not erase past echoes already on the board.
+- Local composer (`remote == false`) still never records `remoteEcho`.
+- 48px-class; keyboard-reachable confirm.
 
 **Implementation**
 
-- Prefer a **Move** affordance on the selected slip (named, 48px) that captures pointer, rather than making the whole slip a `PanGesture` (that fights selection and InteractiveViewer). Alternative: `Listener` on the slip that sets `InteractiveViewer.panEnabled: false` while dragging.
-- Snap optional: 8px grid to match 16px nudge; if snap, document it. Default: free drag, keyboard stays 16px.
-- After pointer-up, `announce` “Moved” for SR users.
-- Pass `onAcknowledgePhrase` from `_CanvasPageState` into `_Atelier`.
+- Fix `hasGrantedConsent` in domain first; existing canvas `_echoConsented` and [echo_ritual_test.dart](../test/features/canvas/echo_ritual_test.dart) keep working if they only grant once.
+- After withdraw, canvas must not keep a stale `_echoConsented == true`. Reload consents on privacy navigation back, or watch consents. Simplest: set `_echoConsented` from latest event inside `_confirmRemoteEcho` and on `_load`; if the person withdraws on another route, next canvas `_load` (or a provider listen) picks it up. Accept “next Summon” if live listen is heavy — but opening the same board without a full app reload should notice. Prefer invalidating after `recordConsent` returns.
+- No SQL migration (`kind` is `text`; `granted` is already bool).
 
 **Files**
 
-- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart) (`_nudge`, `_Atelier`, `InteractiveViewer` ~469)
-- [auth_models.dart](lib/features/auth/domain/auth_models.dart) (already has the method)
-- New widget test in `slip_edit_delete_test.dart` or `recovery_phrase_ack_test.dart`
+- [privacy_models.dart](../lib/features/privacy/domain/privacy_models.dart), both studios `recordConsent`
+- [privacy_page.dart](../lib/features/privacy/presentation/privacy_page.dart), [canvas_page.dart](../lib/features/canvas/presentation/canvas_page.dart)
+- [studio_contract_test.dart](../test/features/studio_contract_test.dart), [echo_ritual_test.dart](../test/features/canvas/echo_ritual_test.dart)
+- New `test/features/privacy/consent_withdraw_test.dart` (domain + widget)
+
+**Tests (TDD first)**
+
+- Domain: grant then withdraw → `hasGrantedConsent` is false; export still contains both rows.
+- Domain: grant, withdraw, grant again → latest true.
+- Widget: remote fake composer (already in echo_ritual) → agree → Privacy → Withdraw → confirm → back to canvas → Summon shows the Art. 6(1)(a) dialog again.
+
+**Difficulties**
+
+- Clock-equal timestamps: if tests insert two rows in the same millisecond, define a stable tie-break (row order / id). Use `clock` already in the project.
+- Don’t treat `necessaryStorage` withdraw as in scope (necessary storage is not optional).
+
+**Deps / bumps.** None.
+
+**Docs.** Privacy policy sentence: echo consent can be withdrawn from Privacy. [legal_catalog.dart](../lib/features/legal/presentation/legal_catalog.dart) + [docs/privacy/policy.md](privacy/policy.md) if that file still omits Art. 7(3).
+
+**Out of scope.** Withdrawing terms-of-use. Deleting Gemini’s copy of a past in-flight slip (we never stored it).
+
+---
+
+## Week 6 — Passkeys first + rights
+
+**Goal.** Password users can add a passkey. Art. 16 rectify and Art. 20 download match the legal copy.
+
+### Issue #17 — Register a passkey from an existing session
+
+**Why.** Sign-in already leads with passkeys. `registerPasskey()` exists and is unused. Password (and OAuth) users cannot add a platform authenticator later. “Passkeys first” is incomplete.
+
+**Acceptance**
+
+- Named control **Add a passkey** after sign-in. Prefer Privacy or Boards chrome (signed-in), not a new settings app. If the session already has `AuthMethod.passkey`, hide or disable with copy “A passkey is already on this account.”
+- In-memory: existing method stays a **fake** success and adds the method. CI must not need an authenticator.
+- Cloud: existing `auth.passkey.startRegistration` / `verifyRegistration` path. Cancel → `AuthCancelledFailure`. Unsupported → reuse `passkeyUnavailable` copy from #11. **No silent fallback to password.**
+- After success, `AuthUser.methods` contains `passkey`; announce “Passkey added.”
+- Do not add a second identity SDK.
+
+**Implementation**
+
+- Call `authRepositoryProvider.registerPasskey()` from the signed-in surface. Busy state like sign-in `_busyId`.
+- In-memory contract test: password sign-up → `registerPasskey` → methods include passkey; signed-out → unavailable.
+- Widget: Enter studio (demo already has passkey — use password sign-up in the test studio, not `enterDemoStudio`).
+
+**Files**
+
+- [sign_in_page.dart](../lib/features/auth/presentation/sign_in_page.dart) only if you put the control there for signed-in visits; otherwise [privacy_page.dart](../lib/features/privacy/presentation/privacy_page.dart) or [boards_page.dart](../lib/features/boards/presentation/boards_page.dart)
+- Both studios (copy only if errors are unclear)
+- [studio_contract_test.dart](../test/features/studio_contract_test.dart)
+- New `test/features/auth/register_passkey_test.dart`
+
+**Tests (TDD first)**
+
+- Domain: signed-out register fails; password user register succeeds in memory.
+- Widget: find `Add a passkey` → tap → find `Passkey added` or equivalent status.
+- [passkey_unavailable_test.dart](../test/features/auth/passkey_unavailable_test.dart) stays green.
+
+**Difficulties**
+
+- Demo studio already lists passkey on the account — widget tests that `enterDemoStudio` will not show Add. Seed a password-only user.
+- Cloud: registering a passkey does **not** change the DEK wrap (still phrase or password). Don’t promise PRF here.
+- Operator: Frankfurt project must already have Passkeys enabled (same as #10).
+
+**Deps / bumps.** None unless `supabase_flutter` 2.x requires a patch already allowed by versioning.
+
+**Docs.** Story 02: “from an existing session you can add a passkey.” README Auth section one line.
+
+**Out of scope.** Multiple passkeys UI. Conditional UI / autofill. Cross-device QR. Making in-memory WebAuthn real.
+
+### Issue #18 — Art. 16 display name + Art. 20 downloadable export
+
+**Why.** Legal copy promises access and port. Export is on-page JSON + clipboard. There is no profile rectify. `displayName` is already in the export payload and `profiles.display_name` exists; UI never writes it (except demo `'Ada'`).
+
+**Acceptance**
+
+- Privacy: field **Display name** + **Save** (Art. 16). Empty allowed (clears to null). Persist in both studios. Export `displayName` matches. Chrome does not need to show the name (no extra identity chrome).
+- Privacy: **Download JSON** beside **Copy JSON**. Web: `Blob` + temporary `<a download="penumbra-export.json">` via `package:web` (already a dep). Filename honest. Don’t POST the bundle anywhere.
+- Legal catalog / privacy policy: name Art. 16 rectification and Art. 20 as a file, not only clipboard.
+- 48px-class; Semantics `Download export as JSON`, `Save display name`.
+
+**Implementation**
+
+- Add `updateDisplayName(String? name)` on privacy or auth repository — one place, both studios. Cloud: `profiles` upsert `display_name` only (do not clobber `wrap_salt` / `wrapped_dek`). In-memory: `_Account.displayName`.
+- Download helper in a tiny `lib/core/web/download_blob.dart` (or privacy presentation) so widget tests can stub it. Don’t crash `flutter test` (IO, not `dart:html`).
+
+**Files**
+
+- [privacy_page.dart](../lib/features/privacy/presentation/privacy_page.dart), both studios, [privacy_repository.dart](../lib/features/privacy/domain/privacy_repository.dart)
+- [legal_catalog.dart](../lib/features/legal/presentation/legal_catalog.dart), [docs/privacy/policy.md](privacy/policy.md)
+- [studio_contract_test.dart](../test/features/studio_contract_test.dart)
+- New `test/features/privacy/export_download_test.dart`
+
+**Tests (TDD first)**
+
+- Domain: set display name → `exportMine().account['displayName']` (or equivalent) matches; cloud path tested only in memory.
+- Widget: Export my data → Download JSON visible; Copy JSON still works.
+- Widget: save display name → status “Display name saved.”
+
+**Difficulties**
+
+- `package:web` in unit tests: inject a callback rather than hitting real Blob.
+- Profiles upsert in cloud must not null out wrap columns — read-modify or send only `id` + `display_name` if PostgREST merge allows it. Verify against existing `_persistWrap` upsert shape (~957–961).
+
+**Deps / bumps.** None.
+
+**Docs.** Legal + privacy policy. No new ADR.
+
+**Out of scope.** Changing email. Avatar. Exporting ciphertext instead of plaintext (export is the data-subject copy; it is decrypted).
+
+---
+
+## Week 7 — Ritual maintainability + a11y
+
+**Goal.** `canvas_page.dart` is splittable. Index and Move are a stronger mitigation for InteractiveViewer still not being a spatial map.
+
+### Issue #19 — Split `canvas_page.dart` with no behaviour change
+
+**Why.** The file grew from ~1067 lines (Week 1 fact) to ~1230 after `paper_slip.dart`. `_Atelier`, `_ComposeBar`, and `_CardIndex` are still private. Week 7 a11y (#20) will be unsafe in a 1200-line state class.
+
+**Acceptance**
+
+- Extract at least `_Atelier`, `_ComposeBar`, `_CardIndex` (and painters if they move cleanly) to `lib/features/canvas/presentation/`. Public or library-private (`atelier.dart`, `compose_bar.dart`, `card_index.dart`) — no new product chrome.
+- Existing canvas widget tests stay green with **no** assertion changes except imports if needed: [echo_ritual_test.dart](../test/features/canvas/echo_ritual_test.dart), [slip_edit_delete_test.dart](../test/features/canvas/slip_edit_delete_test.dart), [recovery_phrase_ack_test.dart](../test/features/canvas/recovery_phrase_ack_test.dart).
+- `dart analyze --fatal-warnings` clean. Visual parity: borders, Fraunces numerals, copper selected state, compose Place/Swatch/Summon.
+
+**Implementation**
+
+- Move widgets first; keep `_CanvasPageState` as the orchestrator (load, consent, drag flag, focus index). Pass callbacks. Do not introduce a canvas Riverpod notifier unless tests force it.
+- Painters can stay in `atelier.dart`.
+- Do this **before** #20 so a11y lands on the extracted Index.
+
+**Files**
+
+- [canvas_page.dart](../lib/features/canvas/presentation/canvas_page.dart) and new presentation files
+- Widget tests listed above (should not need rewrites)
+
+**Tests (TDD first)**
+
+- No new behaviour tests required. Run the existing canvas suite; if extraction breaks finder text (`Place`, `Index`, `Private by default.`), fix the extraction, not the tests.
+
+**Difficulties**
+
+- Private closures and `ref` in the state class. Prefer explicit callbacks over `WidgetRef` in children.
+- `InteractiveViewer` `panEnabled: !_dragging` must keep working after Atelier extraction.
+
+**Deps / bumps.** None.
+
+**Docs.** None unless making-of mentions the file size.
+
+**Out of scope.** Redesign. New panels. State-management rewrite.
+
+### Issue #20 — Index / Move a11y deepening
+
+**Why.** Statement already admits InteractiveViewer is not a spatial map; Index + Move are the mitigation ([docs/accessibility/statement.md](accessibility/statement.md)). Index is mouse-tap `GestureDetector`s. Move announces “Moved” today if that was wired in #7 — verify and deepen: restore focus, speak position, keyboard roving on Index.
+
+**Acceptance**
+
+- Index items are focusable controls (roving tabindex **or** a list where arrow keys move selection without trapping the whole page). Current selected slip stays in sync with `_focusedIndex`.
+- After Move (handle pointer-up or keyboard nudge), `announce` includes enough to reorient (e.g. “Moved. Card II, column …”) — keep copy short. Focus returns to the slip or the Move handle, not the document body.
+- Semantics labels already exist on Index rows (~1016–1021); keep them. Add `Focus` / `Shortcuts` rather than new visible chrome.
+- Statement date bump; known gaps **still** include InteractiveViewer-as-non-map and Flutter web overlay. **No full EAA claim.** Partial EN 301 549.
+- High-contrast: Index selection border still true B/W. Reduced motion: no extra animation.
+
+**Implementation**
+
+- Work in extracted `card_index.dart` from #19. Reuse [motion.dart](../lib/core/a11y/motion.dart) `announce`.
+- Keyboard: Up/Down in Index changes focus; Enter/Space selects (if tap already selects, keep that). Don’t steal canvas arrow-nudge when focus is on the sheet.
+- Widget test with `disableAnimations`, 1400×900, `enterDemoStudio` / Open.
+
+**Files**
+
+- Extracted Index + [canvas_page.dart](../lib/features/canvas/presentation/canvas_page.dart) / [paper_slip.dart](../lib/features/canvas/presentation/paper_slip.dart) (Move handle)
+- [legal_catalog.dart](../lib/features/legal/presentation/legal_catalog.dart), [docs/accessibility/statement.md](accessibility/statement.md)
+- New `test/features/canvas/index_a11y_test.dart`
+
+**Tests (TDD first)**
+
+- Widget: Open seeded board → Index has Semantics selected on the focused card.
+- Widget: tap Index row → corresponding slip selected (already true; keep).
+- Widget: Move handle — after drag or a testable `onMoved` callback, `announce` / semantics live region updated. If full drag vs `InteractiveViewer` is still flaky in CI, test keyboard nudge announce instead and keep one Move-handle `find.bySemanticsLabel('Move')` smoke.
+
+**Difficulties**
+
+- Flutter web semantics overlay remains. Don’t “fix” it with a Forui bump.
+- Roving tabindex vs Flutter `FocusTraversalGroup` — pick one; document in the issue comment when landed.
+- Don’t claim a canvas map.
+
+**Deps / bumps.** None.
+
+**Docs.** A11y statement + catalog accessibility page. Story 03 one sentence if Index behaviour is now stronger than “a list beside the canvas.”
+
+**Out of scope.** Full spatial accessibility tree for `InteractiveViewer`. Screen-reader virtual cursor mapping of x/y pixels.
+
+---
+
+## Week 8 — Honesty pass
+
+**Goal.** Tests cover shipped UI. Making-of, origin, and version agree with Weeks 5–7. Product version **`1.2.0+4`**.
+
+### Issue #21 — Test holes for already-shipped UI
+
+**Why.** Domain contract is strong. Widget coverage skipped several Week 1–2 surfaces: board rename/delete, Move handle, `registerPasskey`, privacy export/erase. Interview TDD story is weaker than the code.
+
+**Acceptance**
+
+- Widget (in-memory, `pumpStudio`, disable animations, 1400×900):
+  - Board **Rename** (change title, chrome or list shows it) and **Delete** (confirm; board gone). Restrict test stays.
+  - Move handle present on a selected human slip (`find.bySemanticsLabel` or named **Move**). Domain [node_motion_test.dart](../test/features/boards/node_motion_test.dart) stays the source of truth for deltas.
+  - Privacy: Export my data shows JSON; Erase with demo/password path does not crash (demo is password+passkey — use the erase password field rules already on the page).
+- Domain: `registerPasskey` if #17 didn’t already add it; erase + export already in [studio_contract_test.dart](../test/features/studio_contract_test.dart) — don’t duplicate, extend.
+- CI: `flutter test` still has no `SUPABASE_*`.
+
+**Implementation**
+
+- Extend [board_lifecycle_test.dart](../test/features/boards/board_lifecycle_test.dart) rather than a fourth pump helper — **or** extract `pumpStudio` to `test/helpers/pump_studio.dart` if copy-paste is now 4+ files.
+- Don’t fight InteractiveViewer for a pixel-perfect drag in CI.
+
+**Files**
+
+- Existing test files above; maybe `test/helpers/pump_studio.dart`
+- [privacy_page.dart](../lib/features/privacy/presentation/privacy_page.dart) only if finders need keys (prefer text finders)
+
+**Tests (TDD first)**
+
+- This issue **is** the tests. Write failing finders first if the widget labels are missing; then fix labels (that is a11y, not scope creep).
+
+**Difficulties**
+
+- Delete board confirm dialog: named buttons, same Forui pattern. Finder collisions with slip **Delete**.
+- Erase navigates to `/` — assert landing, not a leftover `/privacy` session.
+
+**Deps / bumps.** None.
+
+**Docs.** None.
+
+**Out of scope.** Golden screenshots. Live Supabase integration tests.
+
+### Issue #22 — Story / ADR / origin runbook / 1.2.0 honesty
+
+**Why.** [docs/story/01-stack.md](story/01-stack.md) still says “planned Supabase.” Chapter 09 is a closed retrospective of Weeks 1–4. Passkeys fail if `PENUMBRA_ORIGIN` ≠ the Pages origin. Branch protection is still a manual reminder ([docs/versioning.md](versioning.md)). Product work on this cycle must not stay `1.1.1+3`.
+
+**Acceptance**
+
+- Fix `docs/story/01-stack.md` to match ADR-001 / catalog chapter 01 (live Frankfurt; in-memory mirrors it).
+- Add chapter **10** (docs file + [story_catalog.dart](../lib/features/story/data/story_catalog.dart)): retrospective of Weeks 5–8 — phrase re-unlock, Art. 7(3), register passkey, Art. 16/20 download, canvas split, Index a11y. Name what stayed fake (in-memory federated auth, PRF).
+- Operator runbook: short [docs/ops.md](ops.md) (or README section) — `PENUMBRA_ORIGIN` must equal the Cloudflare Pages HTTPS origin; Passkeys enabled on the Frankfurt Auth settings; `CLOUDFLARE_PROJECT_NAME` + tokens for deploy; optional GitHub setting: require **analyze**, **test**, **build-web**, **supply-chain** on `main`.
+- ADR-002: re-unlock with phrase (from #15) noted; PRF still future.
+- `pubspec.yaml` **1.2.0+4** on the product branch (not on the 1.1.1 spec PR).
+- A11y statement date matches the week this lands. Still partial EN 301 549.
+
+**Implementation**
+
+- Catalog body and `docs/story/10-*.md` stay in lockstep (same as chapter 09).
+- Don’t invent a real controller email.
+
+**Files**
+
+- Story catalog + `docs/story/01-stack.md` + new chapter 10
+- [docs/adr/002-key-wrapping.md](adr/002-key-wrapping.md)
+- README and/or `docs/ops.md`
+- [pubspec.yaml](../pubspec.yaml) / lock only if #22 is the last commit on the 1.2.0 PR
+- [docs/accessibility/statement.md](accessibility/statement.md) if #20 didn’t already bump the date
 
 **Tests**
 
-- Widget: OAuth/passkey path in memory — GitHub sign-in is awkward in widget tests; easier to `enterDemoStudio` is wrong (demo has no phrase). Prefer a unit/widget with `InMemoryStudio.signInWithGitHub()` then pump `/boards/...`. If too heavy, a focused test that pumps canvas with a fake auth repo exposing `pendingRecoveryPhrase`.
-- Drag: if widget gesture vs InteractiveViewer is too flaky in CI, extract `BoardNode movedBy(BoardNode node, double dx, double dy, {BoardNode? echo})` in domain (pure) and test that; keep one smoke widget test.
+- `flutter test` + analyze. No new unit tests required unless catalog is parsed in tests (it isn’t).
 
 **Difficulties**
 
-- **Highest Week-1 risk:** `InteractiveViewer` vs child `GestureDetector` arena. If pan steals the drag, users cannot move. If slip steals pan, the sheet cannot be explored. Must toggle `panEnabled` or use a dedicated handle.
-- `_nudge` swallowing errors: while here, `announce` on `ForbiddenFailure` so Week 2 restrict UX is not silent.
-- Flutter web pointer vs trackpad pinch — don’t disable scale (`minScale`/`maxScale` stay 0.5–2.5).
+- Chapter 10 must be written **after** #15–#21 exist, or it will promise work that slipped. If a slice is dropped, say so in the chapter.
+- Don’t claim Cloudflare is configured if `CLOUDFLARE_PROJECT_NAME` is empty.
 
-**Deps / bumps.** None.
+**Deps / bumps.** None required. `flutter pub upgrade` without Forui major only if OSV forces it (same rule as #13).
 
-**Out of scope.** Multi-select, alignment guides, undo stack.
-
----
-
-## Week 2 — Board lifecycle and consent honesty
-
-**Goal.** Legal copy already promises rename, Art. 18 restrict, export, erase. Domain already implements them. UI does not.
-
-### Issue #8 — Board rename, delete, Art. 18 restrict
-
-**Why.** [boards_page.dart](lib/features/boards/presentation/boards_page.dart) create+list only. Restricted is a badge (`board.restricted ? 'Restricted'` ~183). [BoardRepository](lib/features/boards/domain/board_repository.dart) already has `rename` / `delete` / `setRestricted`. Canvas compose bar does not know about restricted.
-
-**Acceptance**
-
-- Each board row: **Rename**, **Restrict** / **Unrestrict**, **Delete** (confirm). Named controls, 48px-class.
-- Restrict → studios refuse `upsert`/`deleteNode` (after #6) → canvas shows a persistent `FAlert` and disables Place / Swatch / Summon / Edit / Delete / drag.
-- Delete board: confirm; navigate away if the open canvas was that id (`go_router` `/boards`).
-- Rename updates chrome title on next load (`PenumbraChrome title: _board!.title`).
-- Widget test: restrict seeded board → Open → Place is absent or disabled; announce/alert contains `Art. 18`.
-
-**Implementation**
-
-- Boards page uses `FutureBuilder` once; keep `_boards` local mutations like `_create` already does.
-- Canvas: `if (_board!.restricted)` short-circuit `_addNote` / `_addSwatch` / `_summonEcho` / `_nudge` / drag.
-- Do not add a settings route; keep actions on the boards list (UX depth over chrome).
-
-**Files**
-
-- [boards_page.dart](lib/features/boards/presentation/boards_page.dart)
-- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart)
-- New `test/features/boards/board_lifecycle_test.dart`
-- Existing domain test `restricted boards refuse writes` stays; extend with delete.
-
-**Difficulties**
-
-- `FutureBuilder` will not refetch after rename if we only mutate `_boards` — that’s fine if we update local state.
-- Cloud delete is RLS-owned; in-memory must match ([in_memory_studio.dart](lib/features/studio/in_memory_studio.dart) `delete`).
-- Restricted **read** still allowed (export/privacy). Don’t hide the board.
-
-**Deps / bumps.** None.
-
-**Docs.** [legal_catalog.dart](lib/features/legal/presentation/legal_catalog.dart) already mentions Art. 18; no copy change unless the UI label differs. Touch [docs/privacy/policy.md](docs/privacy/policy.md) only if the flow changes.
-
-### Issue #9 — Persist remote-echo consent + erase re-auth
-
-**Why.** Remote Gemini path sets a session bool. Refresh = consent again (honest-ish) but export never shows `remoteEcho`. Erase button ignores `eraseAccount({password})`.
-
-**Acceptance**
-
-- Add `ConsentKind.remoteEcho`. `recordConsent` on agree in `_confirmRemoteEcho`. Later summons in this session skip the dialog if a granted event exists; **revocation** is not required this week (no “withdraw echo consent” UI), but a new session should still confirm unless a granted row exists (persisted = skip dialog). Choose **persist across sessions** (true Art. 6(1)(a) record) and document that withdraw is Week-4-or-later if time is gone.
-- `_consentKind` unknown-name fallback today maps to `necessaryStorage` ([supabase_studio.dart](lib/features/studio/supabase_studio.dart) ~830). New enum value must parse `remoteEcho`; unknown stays fallback.
-- Export JSON includes the new kind. [penumbraDataCategories](lib/features/privacy/domain/privacy_models.dart) already has “Optional echo (Gemini)”.
-- Privacy page: password field (12+) for password users; for OAuth, copy that they must have signed in within 5 minutes (`reauthenticate` cloud branch ~227–230). Destructive Erase stays disabled until that is satisfied. Wrong password keeps the account ([studio_contract_test](test/features/studio_contract_test.dart)).
-- After erase success, `go` landing / sign-in; don’t leave a dead `/privacy` session.
-
-**Implementation**
-
-- Canvas should call `privacyRepositoryProvider.recordConsent(ConsentKind.remoteEcho, granted: true)` — **do not** send the slip text to that API.
-- No new SQL migration (kind is `text`). Optional `0004` only if we add a check constraint; skip unless we want DB-level enum (prefer skip — Dart is source of truth).
-- Local composer (`composer.remote == false`) never records `remoteEcho`.
-
-**Files**
-
-- [privacy_models.dart](lib/features/privacy/domain/privacy_models.dart), both studios `recordConsent` / `_consentKind`
-- [canvas_page.dart](lib/features/canvas/presentation/canvas_page.dart), [privacy_page.dart](lib/features/privacy/presentation/privacy_page.dart)
-- [echo_ritual_test.dart](test/features/canvas/echo_ritual_test.dart) — today uses `LocalEchoComposer` so it **must not** require the dialog. Add a test with a fake `remote: true` composer that asserts the dialog copy (`Google LLC`, `Art. 6(1)(a)`) then records consent.
-
-**Difficulties**
-
-- Widget test for **remote** composer needs a fake `EchoComposer` with `remote == true` that does not hit Gemini. The production Gemini path needs `GEMINI_API_KEY`; CI has none.
-- OAuth re-auth window is 5 minutes in cloud studio — document in UI; don’t invent a second OAuth popup this week.
-- Enum addition is a breaking serialization change only if old clients see `remoteEcho` and fall back to `necessaryStorage` (misleading in export). Ship enum + parser together.
-
-**Deps / bumps.** None.
-
----
-
-## Week 3 — Passkeys that match the sign-in page
-
-**Goal.** “Passkeys first” in [sign_in_page.dart](lib/features/auth/presentation/sign_in_page.dart) (~107) must not be a lie on Supabase.
-
-### Issue #10 — Cloud WebAuthn passkeys (no PRF required)
-
-**Why.** `signInWithPasskey` / `registerPasskey` on [SupabaseStudio](lib/features/studio/supabase_studio.dart) hard-return unavailable. ADR-002: wrap DEK with 12-word phrase until PRF exists. In-memory stays a **demo fake**.
-
-**Acceptance**
-
-- Cloud: `navigator.credentials` / `package:web` (already a dep) or `supabase_flutter` Auth WebAuthn API if present in 2.9+. If the plugin in 2.9 cannot do it, bump **`supabase_flutter` within 2.x only** (see bumps). Do not add a second auth SDK.
-- Happy path (HTTPS or localhost, platform authenticator): register or sign in; session DEK still wrapped with recovery phrase on first passkey/OAuth user; phrase UI from #7 still applies.
-- Missing WebAuthn, HTTP non-localhost, user abort: `AuthCancelledFailure` or `AuthUnavailableFailure` with honest copy. Button stays first in the layout. **No silent fallback to password.**
-- RP ID = host of `PENUMBRA_ORIGIN` ([config.dart](lib/core/config.dart)). Cloudflare Pages deploy must use that origin; mismatch = passkeys fail. Document in README.
-- `AuthMethod.passkey` already mapped from `'webauthn'` (~812). Keep that.
-
-**Implementation order**
-
-1. Spike: read `supabase_flutter` 2.9 Auth API for `signInWithWebauthn` / `getAuthenticatorAssuranceLevel`. If absent, check latest 2.x changelog **before** coding UI.
-2. Implement behind `StudioMode.supabase` only.
-3. Keep in-memory `signInWithPasskey` as fake (tests depend on it: [studio_contract_test.dart](test/features/studio_contract_test.dart) ~31).
-
-**Files**
-
-- [supabase_studio.dart](lib/features/studio/supabase_studio.dart), [sign_in_page.dart](lib/features/auth/presentation/sign_in_page.dart) (busy/error copy only)
-- [docs/adr/002-key-wrapping.md](docs/adr/002-key-wrapping.md) — note “cloud WebAuthn shipped; PRF still future”
-- [docs/story/02-auth.md](docs/story/02-auth.md) + catalog chapter 02 — “cloud passkeys are WebAuthn; demo studio still fakes”
-- README Auth section
-
-**Tests**
-
-- No live authenticator in CI. Unit-test a small wrapper with a fake `WebAuthnGateway`: success, abort, unsupported.
-- Existing in-memory passkey test **must remain green**.
-
-**Difficulties (this is the hardest week)**
-
-- Flutter web WebAuthn is poorly documented; `package:web` `CredentialsContainer` vs js-interop breakage across compilers.
-- Supabase project must enable WebAuthn in Auth settings (manual console step — cannot be done from this repo alone). Issue must list: **operator step** on the Frankfurt project.
-- Conditional UI / autofill passkeys: skip.
-- Cross-device QR passkeys: skip.
-- Safari vs Chromium PRF: **out of scope** (stretch below).
-- Relying party ID vs `*.pages.dev` vs custom domain — getting this wrong looks like “passkeys broken”.
-- Don’t store DEK server-side if the wrap path is painful. Recovery phrase remains the wrap.
-
-**Deps / bumps**
-
-- Allowed: `supabase_flutter` `^2.9.0` → latest compatible 2.x if required for WebAuthn. Re-run `flutter pub get` and CI OSV.
-- Allowed: tiny helper only if supabase_flutter still has no API — prefer `package:web` already in pubspec, not a new `passkeys` plugin (those are often mobile-first).
-- Forbidden: Forui bump, Flutter 3.47, Firebase Auth.
-
-**Stretch (only if #10 lands before Wednesday):** WebAuthn PRF extension wraps DEK instead of recovery phrase when `prf` is in `getClientCapabilities`. If unsupported, keep phrase. Do not ship a half-PRF that drops keys.
-
-### Issue #11 — Unavailable-path tests + honest copy
-
-**Why.** Even after #10, many reviewers will run in-memory or HTTP. The button must explain why.
-
-**Acceptance**
-
-- Cloud without WebAuthn: existing `AuthUnavailableFailure` message, maybe tightened: “This browser cannot create a passkey. Use Google, GitHub, a magic link, or a password.”
-- In-memory: keep working fake; making-of says so.
-- [app_widget_test.dart](test/app/app_widget_test.dart) still finds `Continue with a passkey`.
-- Sign-in errors go to `FAlert` (`_error`), not a snackbar.
-
-**Files.** Sign-in page, supabase studio, story 02, ADR-002, new `test/features/auth/passkey_unavailable_test.dart` with a fake studio.
-
-**Difficulties.** Don’t make in-memory start returning unavailable — that would break studio_contract and the demo.
-
-**Deps / bumps.** None beyond #10.
-
----
-
-## Week 4 — Honesty pass
-
-**Goal.** Binary, making-of, env names, and a11y statement agree. App version `1.1.0+2`.
-
-### Issue #12 — A11y lockstep after new controls
-
-**Why.** Weeks 1–2 add Edit/Delete/Move/Restrict. Statement still only mentions Flutter web semantics overlay ([docs/accessibility/statement.md](docs/accessibility/statement.md), [legal_catalog.dart](lib/features/legal/presentation/legal_catalog.dart)).
-
-**Acceptance**
-
-- Every new control has a Semantics name; destructive confirms are keyboard reachable.
-- High-contrast theme: new buttons still true B/W ([theme.dart](lib/app/theme.dart)). Zinc light/dark: spot-check `mutedForeground` on `paper`/`darkPaper` — if below AA for helper text, darken `PenumbraInk.mute` (`0xFF6F675C`) rather than inventing a fifth theme.
-- Statement date bump; list **new** known gaps (InteractiveViewer not in the accessibility tree as a canvas map; drag handle as the mitigation). Still **no full EAA claim**.
-- Widget: summon consent dialog has titled actions (extend echo_ritual with remote fake from #9 if not already).
-
-**Difficulties.** Flutter web semantics overlay will remain; don’t pretend a package bump fixes it. Don’t bump Forui for “better a11y” (Flutter 3.47 trap).
-
-**Deps / bumps.** None required. If `flutter_lints` flags new files, fix code not the linter version unless OSV says so.
-
-### Issue #13 — Env/imprint/ADR/story/OSV hygiene
-
-**Why.** `.env.example` still `LUMEN_*`. ADR-001 still says in-memory mirrors a **future** Supabase. Story chapter 08 is the last shipped chapter. OSV runs on every CI.
-
-**Acceptance**
-
-- [.env.example](.env.example) uses `PENUMBRA_CONTROLLER_NAME`, `PENUMBRA_CONTROLLER_EMAIL`, `PENUMBRA_ORIGIN` matching [config.dart](lib/core/config.dart). Placeholders stay `.invalid`.
-- ADR-001: in-memory **mirrors the live** Frankfurt studio; Forui 0.22.2 / Flutter 3.44 pin restated.
-- Chapter 09 rewritten as retrospective of Weeks 1–4 (what shipped, what stayed fake: in-memory OAuth/passkey/magic, PRF wrap).
-- `pubspec.yaml` version **1.1.0+2**.
-- `flutter pub upgrade` **without** major Forui. If OSV fails, patch the offending package only. Commit `pubspec.lock`.
-- CI still `FLUTTER_VERSION: 3.44.1` unless a CVE in the engine forces a pin change (then re-validate Forui).
-
-**Files.** `.env.example`, `docs/adr/001-stack.md`, story catalog + `docs/story/09-roadmap.md`, `pubspec.yaml` / `pubspec.lock`, README dart-define block, possibly [docs/compliance/processors.md](docs/compliance/processors.md) if WebAuthn/Google paths changed wording.
-
-**Difficulties**
-
-- `flutter pub upgrade` can drag `go_router` 15.x or `riverpod` 2.x minors — run full `flutter test` + `dart analyze --fatal-warnings`.
-- Don’t “fix” controller email to a real inbox in-repo.
-
-**Deps / bumps (allowed in #13)**
-
-- Patch/minor: `cryptography`, `http`, `shared_preferences`, `uuid`, `intl`, `supabase_flutter` (if not already bumped in #10), `url_launcher`
-- Forbidden: `forui` 0.23+, Flutter 3.47+, adding Google Fonts runtime
+**Out of scope.** Auto-tagging `v1.2.0`. Turning on branch protection from this repo (GitHub UI / admin). PRF.
 
 ---
 
@@ -330,7 +412,7 @@ flowchart LR
 
 Each issue uses this skeleton; fill from the sections above:
 
-- Title: as in `#6`–`#13` headings
+- Title: as in `#15`–`#22` headings
 - Labels: `week-N`
 - Body sections: **Why** · **Acceptance** · **Implementation** · **Files** · **Tests (TDD first)** · **Difficulties** · **Deps / bumps** · **Docs** · **Out of scope**
 
@@ -342,8 +424,12 @@ Do not open empty issues and “fill later”. The board is the interview proces
 - CE / NIS2 / ISO / full EAA claims
 - Supabase integration tests in CI
 - Forui 0.26 / Flutter 3.47
-- WebAuthn PRF as a committed deliverable (stretch on #10 only)
+- WebAuthn PRF as a committed deliverable
+- Making in-memory OAuth / passkey / magic real
+- Auto-tagging as a required deliverable
 
 ## Cadence
 
-Each coding week: failing domain test → studio both paths → UI → widget test → making-of/ADR touch → `gh issue close`. Reviewers keep using **Enter the studio** (in-memory). Cloud checks need both `SUPABASE_*` dart-defines plus, for Week 3, WebAuthn enabled on the Frankfurt project.
+Each coding week: failing domain test → studio both paths → UI → widget test → making-of/ADR touch → `gh issue close`. Reviewers keep using **Enter the studio** (in-memory). Cloud checks need both `SUPABASE_*` dart-defines, WebAuthn enabled on the Frankfurt project, and `PENUMBRA_ORIGIN` equal to the Pages origin.
+
+Product implementation: branch `minor/v1.2.0-{slug}` from up-to-date `main`, bump to `1.2.0+4`, PR title `v1.2.0:`. This spec PR is `patch/v1.1.1-next-cycle-roadmap` only.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: penumbra
 description: A privacy-first visual thinking studio. Private by default. Visible only to you. Accessible by design.
 publish_to: "none"
-version: 1.1.0+2
+version: 1.1.1+3
 
 environment:
   sdk: ^3.12.1


### PR DESCRIPTION
## Summary
- Publish the Weeks 5–8 enhancement spec in `docs/roadmap.md` (phrase unlock, Art. 7(3), register passkey, Art. 16/20, canvas split, Index a11y, test holes, honesty pass).
- Point `docs/github.md` and `AGENTS.md` at issues #15–#22. Docs-only patch bump to `1.1.1+3`.

Product implementation stays a later `minor/v1.2.0-…` branch. This PR does not close those issues.

## Test plan
- [ ] CI jobs analyze, test, build-web, and supply-chain are green
- [ ] https://github.com/sebbeflebbe/penumbra/blob/main/docs/roadmap.md shows Weeks 5–8 after merge
- [ ] Issues #15–#22 remain open on Project 2 (Todo)


Made with [Cursor](https://cursor.com)